### PR TITLE
Fix #212: Crypto 3.0: Remove deprecated methods

### DIFF
--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/activation/PowerAuthClientActivation.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/activation/PowerAuthClientActivation.java
@@ -48,33 +48,6 @@ public class PowerAuthClientActivation {
     private final SignatureUtils signatureUtils = new SignatureUtils();
 
     /**
-     * Verify the signature of activation data using Master Public Key. Signature is computed as the concatenation of activationIdShort and activationOTP,
-     * separated with the "-" character:
-     *
-     * activationData = activationIdShort + "-" + activationOTP
-     *
-     * @param activationIdShort Short activation ID.
-     * @param activationOTP Activation OTP value.
-     * @param signature Activation data signature.
-     * @param masterPublicKey Master Public Key.
-     * @return Returns "true" if the signature matches activation data, "false" otherwise.
-     * @throws InvalidKeyException If provided master public key is invalid.
-     *
-     * @deprecated Use {@link #verifyActivationCodeSignature(String, byte[], PublicKey)}.
-     *
-     */
-    @Deprecated
-    public boolean verifyActivationDataSignature(String activationIdShort, String activationOTP, byte[] signature, PublicKey masterPublicKey) throws InvalidKeyException {
-        try {
-            byte[] bytes = (activationIdShort + "-" + activationOTP).getBytes("UTF-8");
-            return signatureUtils.validateECDSASignature(bytes, signature, masterPublicKey);
-        } catch (SignatureException | UnsupportedEncodingException ex) {
-            Logger.getLogger(PowerAuthClientActivation.class.getName()).log(Level.SEVERE, null, ex);
-        }
-        return false;
-    }
-
-    /**
      * Verify the signature of activation code using Master Public Key.
      *
      * @param activationCode Activation code.

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/signature/PowerAuthClientSignature.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/signature/PowerAuthClientSignature.java
@@ -31,27 +31,6 @@ public class PowerAuthClientSignature {
     private final SignatureUtils signatureUtils = new SignatureUtils();
 
     /**
-     * Compute a PowerAuth 2.0 signature for given data, signature keys and
-     * counter. Signature keys are symmetric keys deduced using
-     * private device key KEY_DEVICE_PRIVATE and server public key
-     * KEY_SERVER_PUBLIC, and then using KDF function with proper index. See
-     * PowerAuth protocol specification for details.
-     *
-     * PowerAuth protocol version: 2.0
-     *
-     * @deprecated Use {@link #signatureForData(byte[], List, byte[])}.
-     *
-     * @param data Data to be signed.
-     * @param signatureKeys A signature keys.
-     * @param ctr Numeric counter / index of the derived key KEY_DERIVED.
-     * @return PowerAuth 2.0 signature for given data.
-     */
-    @Deprecated
-    public String signatureForData(byte[] data, List<SecretKey> signatureKeys, long ctr) {
-        return signatureUtils.computePowerAuthSignature(data, signatureKeys, ctr);
-    }
-
-    /**
      * Compute a PowerAuth 3.0 signature for given data, signature keys and
      * counter. Signature keys are symmetric keys deduced using
      * private device key KEY_DEVICE_PRIVATE and server public key

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/IdentifierGenerator.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/IdentifierGenerator.java
@@ -58,34 +58,6 @@ public class IdentifierGenerator {
     }
 
     /**
-     * Generate a new short activation ID. The format of short activation ID is
-     * "ABCDE-FGHIJ" - two components, each of them 5 random characters from
-     * Base32 encoding, separated by "-" character.
-     *
-     * Use {@link #generateActivationCode()}.
-     *
-     * @return A new short activation ID.
-     */
-    @Deprecated
-    public String generateActivationIdShort() {
-        return generateBase32Token() + "-" + generateBase32Token();
-    }
-
-    /**
-     * Generate a new activation OTP. The format of activation OTP is
-     * "ABCDE-FGHIJ" - two components, each of them 5 random characters from
-     * Base32 encoding, separated by "-" character.
-     *
-     * Use {@link #generateActivationCode()}.
-     *
-     * @return A new activation OTP.
-     */
-    @Deprecated
-    public String generateActivationOTP() {
-        return generateBase32Token() + "-" + generateBase32Token();
-    }
-
-    /**
      * Generate a new string of a default length (5) with characters from Base32 encoding.
      *
      * @return New string with Base32 characters of a given length.

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/SignatureUtils.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/SignatureUtils.java
@@ -78,29 +78,6 @@ public class SignatureUtils {
     }
 
     /**
-     * Compute PowerAuth 2.0 signature for given data using a secret signature
-     * keys and counter.
-     *
-     * PowerAuth protocol version: 2.0
-     *
-     * @deprecated Use {@link #computePowerAuthSignature(byte[], List, byte[])}.
-     *
-     * @param data Data to be signed.
-     * @param signatureKeys Keys for computing the signature.
-     * @param counter Numeric counter / derived key index.
-     * @return PowerAuth 2.0 signature for given data.
-     *
-     */
-    @Deprecated
-    public String computePowerAuthSignature(byte[] data, List<SecretKey> signatureKeys, long counter) {
-        // Prepare a counter
-        byte[] ctrData = ByteBuffer.allocate(16).putLong(8, counter).array();
-
-        // Compute signature using byte counter
-        return computePowerAuthSignature(data, signatureKeys, ctrData);
-    }
-
-    /**
      * Compute PowerAuth signature for given data using a secret signature keys and counter byte array.
      *
      * Logic is used in PowerAuth protocol versions 2.0 and 3.0.
@@ -142,24 +119,6 @@ public class SignatureUtils {
         }
 
         return Joiner.on("-").join(signatureComponents);
-    }
-
-    /**
-     * Validate the PowerAuth 2.0 signature for given data using provided keys.
-     *
-     * PowerAuth protocol version: 2.0
-     *
-     * @deprecated Use {@link #validatePowerAuthSignature(byte[], String, List, byte[])}.
-     *
-     * @param data Data that were signed.
-     * @param signature Data signature.
-     * @param signatureKeys Keys for signature validation.
-     * @param counter Counter.
-     * @return Return "true" if signature matches, "false" otherwise.
-     */
-    @Deprecated
-    public boolean validatePowerAuthSignature(byte[] data, String signature, List<SecretKey> signatureKeys, long counter) {
-        return signature.equals(computePowerAuthSignature(data, signatureKeys, counter));
     }
 
     /**

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/activation/PowerAuthServerActivation.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/activation/PowerAuthServerActivation.java
@@ -62,36 +62,6 @@ public class PowerAuthServerActivation {
     }
 
     /**
-     * Generate a pseudo-unique short activation ID. Technically, the result is
-     * a string with 5+5 random Base32 characters (separated with the "-"
-     * character). PowerAuth Server implementation should validate that this
-     * identifier is unique among all activation records in CREATED or OTP_USED
-     * states, so that there are no collisions in activations.
-     *
-     * Use {@link #generateActivationCode()}.
-     *
-     * @return A new short activation ID.
-     */
-    @Deprecated
-    public String generateActivationIdShort() {
-        return identifierGenerator.generateActivationIdShort();
-    }
-
-    /**
-     * Generate a pseudo-unique activation OTP. Technically, the result is a
-     * string with 5+5 random Base32 characters (separated with the "-"
-     * character).
-     *
-     * Use {@link #generateActivationCode()}.
-     *
-     * @return A new activation OTP.
-     */
-    @Deprecated
-    public String generateActivationOTP() {
-        return identifierGenerator.generateActivationOTP();
-    }
-
-    /**
      * Generate a pseudo-unique activation code. The format of activation code is "ABCDE-FGHIJ-KLMNO-PQRST".
      *
      * @return A new activation code.
@@ -107,36 +77,6 @@ public class PowerAuthServerActivation {
      */
     public KeyPair generateServerKeyPair() {
         return new KeyGenerator().generateKeyPair();
-    }
-
-    /**
-     * Generate signature for the activation data. Activation data are
-     * constructed as a concatenation of activationIdShort and activationOTP,
-     * both values are separated with the "-" character:
-     *
-     * activationData = activationIdShort + "_" + activationOTP
-     *
-     * Signature is then computed using the master private key.
-     *
-     * @param activationIdShort Short activation ID.
-     * @param activationOTP Activation OTP value.
-     * @param masterPrivateKey Master Private Key.
-     * @return Signature of activation data using Master Private Key.
-     * @throws InvalidKeyException In case Master Private Key is invalid.
-     *
-     * Use {@link #generateActivationSignature(String, PrivateKey)}.
-     *
-     */
-    @Deprecated
-    public byte[] generateActivationSignature(String activationIdShort, String activationOTP,
-                                              PrivateKey masterPrivateKey) throws InvalidKeyException {
-        try {
-            byte[] bytes = (activationIdShort + "-" + activationOTP).getBytes("UTF-8");
-            return signatureUtils.computeECDSASignature(bytes, masterPrivateKey);
-        } catch (UnsupportedEncodingException | SignatureException ex) {
-            Logger.getLogger(PowerAuthServerActivation.class.getName()).log(Level.SEVERE, null, ex);
-        }
-        return null;
     }
 
     /**

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/signature/PowerAuthServerSignature.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/signature/PowerAuthServerSignature.java
@@ -32,25 +32,6 @@ public class PowerAuthServerSignature {
     private final SignatureUtils signatureUtils = new SignatureUtils();
 
     /**
-     * Verify a PowerAuth 2.0 signature against data using signature key list and
-     * counter.
-     *
-     * PowerAuth protocol version: 2.0
-     *
-     * @deprecated Use {@link #verifySignatureForData(byte[], String, List, byte[])}.
-     *
-     * @param data Signed data.
-     * @param signature Signature for the data.
-     * @param signatureKeys Keys used for signature.
-     * @param ctr Numeric counter / derived signing key index.
-     * @return Returns "true" if the signature matches, "false" otherwise.
-     */
-    @Deprecated
-    public boolean verifySignatureForData(byte[] data, String signature, List<SecretKey> signatureKeys, long ctr) {
-        return signatureUtils.validatePowerAuthSignature(data, signature, signatureKeys, ctr);
-    }
-
-    /**
      * Verify a PowerAuth 3.0 signature against data using signature key list and
      * counter.
      *

--- a/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/signature/PowerAuthSignatureTest.java
+++ b/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/signature/PowerAuthSignatureTest.java
@@ -30,6 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.crypto.SecretKey;
+import java.nio.ByteBuffer;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -116,7 +117,8 @@ public class PowerAuthSignatureTest {
                 SecretKey signatureClientKey = clientKeyFactory.generateClientSignaturePossessionKey(masterClientKey);
                 System.out.println("### Client Signature Key: " + BaseEncoding.base64().encode(keyConvertor.convertSharedSecretKeyToBytes(signatureClientKey)));
 
-                String signature = clientSignature.signatureForData(data, Collections.singletonList(signatureClientKey), ctr);
+                byte[] ctrData = ByteBuffer.allocate(16).putLong(8, ctr).array();
+                String signature = clientSignature.signatureForData(data, Collections.singletonList(signatureClientKey), ctrData);
 
                 System.out.println("## Client Signature: " + signature);
 
@@ -131,7 +133,8 @@ public class PowerAuthSignatureTest {
                 System.out.println("### Server Signature Key: " + BaseEncoding.base64().encode(keyConvertor.convertSharedSecretKeyToBytes(signatureServerKey)));
                 assertEquals(signatureClientKey, signatureServerKey);
 
-                boolean isSignatureValid = serverSignature.verifySignatureForData(data, signature, Collections.singletonList(signatureServerKey), ctr);
+                ctrData = ByteBuffer.allocate(16).putLong(8, ctr).array();
+                boolean isSignatureValid = serverSignature.verifySignatureForData(data, signature, Collections.singletonList(signatureServerKey), ctrData);
                 System.out.println("## Signature valid: " + (isSignatureValid ? "TRUE" : "FALSE"));
                 assertTrue(isSignatureValid);
 
@@ -156,7 +159,8 @@ public class PowerAuthSignatureTest {
                 SecretKey signatureClientKeyKnowledge = clientKeyFactory.generateClientSignatureKnowledgeKey(masterClientKey);
                 System.out.println("### Client Signature Key - Knowledge:  " + BaseEncoding.base64().encode(keyConvertor.convertSharedSecretKeyToBytes(signatureClientKeyKnowledge)));
 
-                String signature = clientSignature.signatureForData(data, Arrays.asList(signatureClientKeyPossession, signatureClientKeyKnowledge), ctr);
+                byte[] ctrData = ByteBuffer.allocate(16).putLong(8, ctr).array();
+                String signature = clientSignature.signatureForData(data, Arrays.asList(signatureClientKeyPossession, signatureClientKeyKnowledge), ctrData);
 
                 System.out.println("## Client Signature: " + signature);
 
@@ -174,7 +178,8 @@ public class PowerAuthSignatureTest {
                 System.out.println("### Server Signature Key: " + BaseEncoding.base64().encode(keyConvertor.convertSharedSecretKeyToBytes(signatureServerKeyKnowledge)));
                 assertEquals(signatureClientKeyKnowledge, signatureServerKeyKnowledge);
 
-                boolean isSignatureValid = serverSignature.verifySignatureForData(data, signature, Arrays.asList(signatureServerKeyPossession, signatureClientKeyKnowledge), ctr);
+                ctrData = ByteBuffer.allocate(16).putLong(8, ctr).array();
+                boolean isSignatureValid = serverSignature.verifySignatureForData(data, signature, Arrays.asList(signatureServerKeyPossession, signatureClientKeyKnowledge), ctrData);
                 System.out.println("## Signature valid: " + (isSignatureValid ? "TRUE" : "FALSE"));
                 assertTrue(isSignatureValid);
 


### PR DESCRIPTION
Deprecated methods can be removed, there are no more usages in PowerAuth projects.