### PR TITLE
Fix #219: Replace logging with exceptions

### DIFF
--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/activation/PowerAuthClientActivation.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/activation/PowerAuthClientActivation.java
@@ -56,23 +56,20 @@ public class PowerAuthClientActivation {
      * @return Returns "true" if the signature matches activation data, "false" otherwise.
      * @throws InvalidKeyException If provided master public key is invalid.
      * @throws GenericCryptoException In case signature computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public boolean verifyActivationCodeSignature(String activationCode, byte[] signature, PublicKey masterPublicKey) throws InvalidKeyException, GenericCryptoException {
-        try {
-            byte[] bytes = activationCode.getBytes(StandardCharsets.UTF_8);
-            return signatureUtils.validateECDSASignature(bytes, signature, masterPublicKey);
-        } catch (SignatureException ex) {
-            throw new GenericCryptoException(ex.getMessage(), ex);
-        }
+    public boolean verifyActivationCodeSignature(String activationCode, byte[] signature, PublicKey masterPublicKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
+        byte[] bytes = activationCode.getBytes(StandardCharsets.UTF_8);
+        return signatureUtils.validateECDSASignature(bytes, signature, masterPublicKey);
     }
 
     /**
      * Generate a device related activation key pair.
      *
      * @return A new device key pair.
-     * @throws GenericCryptoException In case cryptography provider is incorrectly initialized.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public KeyPair generateDeviceKeyPair() throws GenericCryptoException {
+    public KeyPair generateDeviceKeyPair() throws CryptoProviderException {
         return new KeyGenerator().generateKeyPair();
     }
 
@@ -131,8 +128,9 @@ public class PowerAuthClientActivation {
      * @return An encrypted device public key.
      * @throws InvalidKeyException In case provided public key is invalid.
      * @throws GenericCryptoException In case encryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] encryptDevicePublicKey(PublicKey devicePublicKey, PrivateKey clientEphemeralPrivateKey, PublicKey masterPublicKey, String activationOTP, String activationIdShort, byte[] activationNonce) throws InvalidKeyException, GenericCryptoException {
+    public byte[] encryptDevicePublicKey(PublicKey devicePublicKey, PrivateKey clientEphemeralPrivateKey, PublicKey masterPublicKey, String activationOTP, String activationIdShort, byte[] activationNonce) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         try {
             KeyGenerator keyGenerator = new KeyGenerator();
             byte[] activationIdShortBytes = activationIdShort.getBytes(StandardCharsets.UTF_8);
@@ -158,17 +156,14 @@ public class PowerAuthClientActivation {
      * @return Returns "true" if signature matches encrypted data, "false" otherwise.
      * @throws InvalidKeyException If provided master public key is invalid.
      * @throws GenericCryptoException In case signature computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public boolean verifyServerDataSignature(String activationId, byte[] C_serverPublicKey, byte[] signature, PublicKey masterPublicKey) throws InvalidKeyException, GenericCryptoException {
-        try {
-            byte[] activationIdBytes = activationId.getBytes(StandardCharsets.UTF_8);
-            String activationIdBytesBase64 = BaseEncoding.base64().encode(activationIdBytes);
-            String C_serverPublicKeyBase64 = BaseEncoding.base64().encode(C_serverPublicKey);
-            byte[] result = (activationIdBytesBase64 + "&" + C_serverPublicKeyBase64).getBytes(StandardCharsets.UTF_8);
-            return signatureUtils.validateECDSASignature(result, signature, masterPublicKey);
-        } catch (SignatureException ex) {
-            throw new GenericCryptoException(ex.getMessage(), ex);
-        }
+    public boolean verifyServerDataSignature(String activationId, byte[] C_serverPublicKey, byte[] signature, PublicKey masterPublicKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
+        byte[] activationIdBytes = activationId.getBytes(StandardCharsets.UTF_8);
+        String activationIdBytesBase64 = BaseEncoding.base64().encode(activationIdBytes);
+        String C_serverPublicKeyBase64 = BaseEncoding.base64().encode(C_serverPublicKey);
+        byte[] result = (activationIdBytesBase64 + "&" + C_serverPublicKeyBase64).getBytes(StandardCharsets.UTF_8);
+        return signatureUtils.validateECDSASignature(result, signature, masterPublicKey);
     }
 
     /**
@@ -215,13 +210,13 @@ public class PowerAuthClientActivation {
      *
      * @param devicePublicKey Public key for computing fingerprint.
      * @return Fingerprint of the public key.
-     * @throws GenericCryptoException In case cryptography provider is incorrectly initialized.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public String computeDevicePublicKeyFingerprint(PublicKey devicePublicKey) throws GenericCryptoException {
+    public String computeDevicePublicKeyFingerprint(PublicKey devicePublicKey) throws CryptoProviderException {
         try {
             return ECPublicKeyFingerprint.compute(((ECPublicKey)devicePublicKey));
         } catch (NoSuchAlgorithmException ex) {
-            throw new GenericCryptoException(ex.getMessage(), ex);
+            throw new CryptoProviderException(ex.getMessage(), ex);
         }
     }
 
@@ -233,8 +228,9 @@ public class PowerAuthClientActivation {
      * @return Status information from the status blob.
      * @throws InvalidKeyException When invalid key is provided.
      * @throws GenericCryptoException In case decryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public ActivationStatusBlobInfo getStatusFromEncryptedBlob(byte[] cStatusBlob, SecretKey transportKey) throws InvalidKeyException, GenericCryptoException {
+    public ActivationStatusBlobInfo getStatusFromEncryptedBlob(byte[] cStatusBlob, SecretKey transportKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         try {
 
             if (cStatusBlob.length != 32) {

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/activation/PowerAuthClientActivation.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/activation/PowerAuthClientActivation.java
@@ -101,8 +101,9 @@ public class PowerAuthClientActivation {
      * @param applicationSecret Application secret.
      * @return Signature bytes.
      * @throws GenericCryptoException In case hash computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] computeApplicationSignature(String activationIdShort, byte[] activationNonce, byte[] encryptedDevicePublicKey, byte[] applicationKey, byte[] applicationSecret) throws GenericCryptoException {
+    public byte[] computeApplicationSignature(String activationIdShort, byte[] activationNonce, byte[] encryptedDevicePublicKey, byte[] applicationKey, byte[] applicationSecret) throws GenericCryptoException, CryptoProviderException {
         String signatureBaseString = activationIdShort + "&"
                 + BaseEncoding.base64().encode(activationNonce) + "&"
                 + BaseEncoding.base64().encode(encryptedDevicePublicKey) + "&"
@@ -185,8 +186,9 @@ public class PowerAuthClientActivation {
      * @return Decrypted server public key.
      * @throws InvalidKeyException In case some of the provided keys is invalid.
      * @throws GenericCryptoException In case decryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public PublicKey decryptServerPublicKey(byte[] C_serverPublicKey, PrivateKey devicePrivateKey, PublicKey ephemeralPublicKey, String activationOTP, String activationIdShort, byte[] activationNonce) throws InvalidKeyException, GenericCryptoException {
+    public PublicKey decryptServerPublicKey(byte[] C_serverPublicKey, PrivateKey devicePrivateKey, PublicKey ephemeralPublicKey, String activationOTP, String activationIdShort, byte[] activationNonce) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
 
         try {
             KeyGenerator keyGenerator = new KeyGenerator();
@@ -200,7 +202,7 @@ public class PowerAuthClientActivation {
             byte[] decryptedServerPublicKeyBytes = aes.decrypt(decryptedTMP, activationNonce, otpBasedSymmetricKey);
 
             return PowerAuthConfiguration.INSTANCE.getKeyConvertor().convertBytesToPublicKey(decryptedServerPublicKeyBytes);
-        } catch (IllegalBlockSizeException | BadPaddingException | InvalidKeySpecException | CryptoProviderException ex) {
+        } catch (IllegalBlockSizeException | BadPaddingException | InvalidKeySpecException ex) {
             throw new GenericCryptoException(ex.getMessage(), ex);
         }
     }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/encryptor/ClientNonPersonalizedEncryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/encryptor/ClientNonPersonalizedEncryptor.java
@@ -54,10 +54,11 @@ public class ClientNonPersonalizedEncryptor {
      * Encrypt data using current encryptor (non-personalized encryption).
      * @param data Original data.
      * @return Encrypted payload.
+     * @throws InvalidKeyException In case encryption key is invalid.
      * @throws GenericCryptoException In case encryption fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public NonPersonalizedEncryptedMessage encrypt(byte[] data) throws GenericCryptoException, CryptoProviderException {
+    public NonPersonalizedEncryptedMessage encrypt(byte[] data) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         return this.encryptor.encrypt(data);
     }
 
@@ -65,10 +66,11 @@ public class ClientNonPersonalizedEncryptor {
      * Decrypt original data from encrypted using current encryptor (non-personalized encryption).
      * @param message Encrypted payload message.
      * @return Original data.
+     * @throws InvalidKeyException In case encryption key is invalid.
      * @throws GenericCryptoException In case decryption fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] decrypt(NonPersonalizedEncryptedMessage message) throws GenericCryptoException, CryptoProviderException {
+    public byte[] decrypt(NonPersonalizedEncryptedMessage message) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         return this.encryptor.decrypt(message);
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/encryptor/ClientNonPersonalizedEncryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/encryptor/ClientNonPersonalizedEncryptor.java
@@ -6,6 +6,7 @@ import io.getlime.security.powerauth.crypto.lib.encryptor.model.NonPersonalizedE
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
@@ -29,8 +30,9 @@ public class ClientNonPersonalizedEncryptor {
      * @param masterPublicKey Master Server Public Key.
      * @throws InvalidKeyException In case an invalid key is provided.
      * @throws GenericCryptoException In case of any other cryptography error.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public ClientNonPersonalizedEncryptor(byte[] appKey, PublicKey masterPublicKey) throws InvalidKeyException, GenericCryptoException {
+    public ClientNonPersonalizedEncryptor(byte[] appKey, PublicKey masterPublicKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
 
         final KeyGenerator generator = new KeyGenerator();
         byte[] sessionIndex = generator.generateRandomBytes(16);

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/encryptor/ClientNonPersonalizedEncryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/encryptor/ClientNonPersonalizedEncryptor.java
@@ -37,9 +37,6 @@ public class ClientNonPersonalizedEncryptor {
         final KeyGenerator generator = new KeyGenerator();
         byte[] sessionIndex = generator.generateRandomBytes(16);
         KeyPair ephemeralKeyPair = generator.generateKeyPair();
-        if (ephemeralKeyPair == null) {
-            throw new InvalidKeyException("Unable to generate EC key pair. Check your Bouncy Castle settings.");
-        }
         final SecretKey ephemeralSecretKey = generator.computeSharedKey(ephemeralKeyPair.getPrivate(), masterPublicKey);
         final SecretKey sessionRelatedSecretKey = generator.deriveSecretKeyHmac(ephemeralSecretKey, sessionIndex);
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/encryptor/ClientNonPersonalizedEncryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/encryptor/ClientNonPersonalizedEncryptor.java
@@ -4,6 +4,7 @@ import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.encryptor.NonPersonalizedEncryptor;
 import io.getlime.security.powerauth.crypto.lib.encryptor.model.NonPersonalizedEncryptedMessage;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 
 import javax.crypto.SecretKey;
@@ -27,8 +28,9 @@ public class ClientNonPersonalizedEncryptor {
      * @param appKey App key.
      * @param masterPublicKey Master Server Public Key.
      * @throws InvalidKeyException In case an invalid key is provided.
+     * @throws GenericCryptoException In case of any other cryptography error.
      */
-    public ClientNonPersonalizedEncryptor(byte[] appKey, PublicKey masterPublicKey) throws InvalidKeyException {
+    public ClientNonPersonalizedEncryptor(byte[] appKey, PublicKey masterPublicKey) throws InvalidKeyException, GenericCryptoException {
 
         final KeyGenerator generator = new KeyGenerator();
         byte[] sessionIndex = generator.generateRandomBytes(16);
@@ -49,18 +51,20 @@ public class ClientNonPersonalizedEncryptor {
     /**
      * Encrypt data using current encryptor (non-personalized encryption).
      * @param data Original data.
-     * @return Encrypted payload, or null in case decryption fails.
+     * @return Encrypted payload.
+     * @throws GenericCryptoException In case encryption fails.
      */
-    public NonPersonalizedEncryptedMessage encrypt(byte[] data) {
+    public NonPersonalizedEncryptedMessage encrypt(byte[] data) throws GenericCryptoException {
         return this.encryptor.encrypt(data);
     }
 
     /**
      * Decrypt original data from encrypted using current encryptor (non-personalized encryption).
      * @param message Encrypted payload message.
-     * @return Original data, or null in case decryption fails.
+     * @return Original data.
+     * @throws GenericCryptoException In case decryption fails.
      */
-    public byte[] decrypt(NonPersonalizedEncryptedMessage message) {
+    public byte[] decrypt(NonPersonalizedEncryptedMessage message) throws GenericCryptoException {
         return this.encryptor.decrypt(message);
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/encryptor/ClientNonPersonalizedEncryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/encryptor/ClientNonPersonalizedEncryptor.java
@@ -66,7 +66,7 @@ public class ClientNonPersonalizedEncryptor {
      * Decrypt original data from encrypted using current encryptor (non-personalized encryption).
      * @param message Encrypted payload message.
      * @return Original data.
-     * @throws InvalidKeyException In case encryption key is invalid.
+     * @throws InvalidKeyException In case decryption key is invalid.
      * @throws GenericCryptoException In case decryption fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/encryptor/ClientNonPersonalizedEncryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/encryptor/ClientNonPersonalizedEncryptor.java
@@ -55,8 +55,9 @@ public class ClientNonPersonalizedEncryptor {
      * @param data Original data.
      * @return Encrypted payload.
      * @throws GenericCryptoException In case encryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public NonPersonalizedEncryptedMessage encrypt(byte[] data) throws GenericCryptoException {
+    public NonPersonalizedEncryptedMessage encrypt(byte[] data) throws GenericCryptoException, CryptoProviderException {
         return this.encryptor.encrypt(data);
     }
 
@@ -65,8 +66,9 @@ public class ClientNonPersonalizedEncryptor {
      * @param message Encrypted payload message.
      * @return Original data.
      * @throws GenericCryptoException In case decryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] decrypt(NonPersonalizedEncryptedMessage message) throws GenericCryptoException {
+    public byte[] decrypt(NonPersonalizedEncryptedMessage message) throws GenericCryptoException, CryptoProviderException {
         return this.encryptor.decrypt(message);
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/keyfactory/PowerAuthClientKeyFactory.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/keyfactory/PowerAuthClientKeyFactory.java
@@ -20,6 +20,7 @@ import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthDerivedKey;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
@@ -92,8 +93,9 @@ public class PowerAuthClientKeyFactory {
      * @return List with keys constructed from master secret that are needed to
      *         get requested signature type.
      * @throws GenericCryptoException In case key derivation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public List<SecretKey> keysForSignatureType(PowerAuthSignatureTypes signatureType, SecretKey masterSecretKey) throws GenericCryptoException {
+    public List<SecretKey> keysForSignatureType(PowerAuthSignatureTypes signatureType, SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
 
         List<SecretKey> signatureKeys = new ArrayList<>();
 
@@ -152,9 +154,9 @@ public class PowerAuthClientKeyFactory {
      * @return Computed symmetric key KEY_MASTER_SECRET.
      * @throws InvalidKeyException
      *             In case some provided key is invalid.
-     * @throws GenericCryptoException In case shared key computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateClientMasterSecretKey(PrivateKey devicePrivateKey, PublicKey serverPublicKey) throws InvalidKeyException, GenericCryptoException {
+    public SecretKey generateClientMasterSecretKey(PrivateKey devicePrivateKey, PublicKey serverPublicKey) throws InvalidKeyException, CryptoProviderException {
         return keyGenerator.computeSharedKey(devicePrivateKey, serverPublicKey);
     }
 
@@ -167,8 +169,9 @@ public class PowerAuthClientKeyFactory {
      *            Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_BIOMETRY.
      * @throws GenericCryptoException In case key derivation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateClientSignatureBiometryKey(SecretKey masterSecretKey) throws GenericCryptoException {
+    public SecretKey generateClientSignatureBiometryKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(masterSecretKey, PowerAuthDerivedKey.SIGNATURE_BIOMETRY.getIndex());
     }
 
@@ -181,8 +184,9 @@ public class PowerAuthClientKeyFactory {
      *            Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_KNOWLEDGE.
      * @throws GenericCryptoException In case key derivation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateClientSignatureKnowledgeKey(SecretKey masterSecretKey) throws GenericCryptoException {
+    public SecretKey generateClientSignatureKnowledgeKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(masterSecretKey, PowerAuthDerivedKey.SIGNATURE_KNOWLEDGE.getIndex());
     }
 
@@ -195,8 +199,9 @@ public class PowerAuthClientKeyFactory {
      *            Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_POSSESSION.
      * @throws GenericCryptoException In case key derivation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateClientSignaturePossessionKey(SecretKey masterSecretKey) throws GenericCryptoException {
+    public SecretKey generateClientSignaturePossessionKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(masterSecretKey, PowerAuthDerivedKey.SIGNATURE_POSSESSION.getIndex());
     }
 
@@ -209,8 +214,9 @@ public class PowerAuthClientKeyFactory {
      *            Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_ENCRYPTED_VAULT.
      * @throws GenericCryptoException In case key derivation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateServerEncryptedVaultKey(SecretKey masterSecretKey) throws GenericCryptoException {
+    public SecretKey generateServerEncryptedVaultKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(masterSecretKey, PowerAuthDerivedKey.ENCRYPTED_VAULT.getIndex());
     }
 
@@ -223,8 +229,9 @@ public class PowerAuthClientKeyFactory {
      *            Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_TRANSPORT.
      * @throws GenericCryptoException In case key derivation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateServerTransportKey(SecretKey masterSecretKey) throws GenericCryptoException {
+    public SecretKey generateServerTransportKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(masterSecretKey, PowerAuthDerivedKey.TRANSPORT.getIndex());
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/keyfactory/PowerAuthClientKeyFactory.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/keyfactory/PowerAuthClientKeyFactory.java
@@ -19,6 +19,7 @@ package io.getlime.security.powerauth.crypto.client.keyfactory;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthDerivedKey;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 
 import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
@@ -90,8 +91,9 @@ public class PowerAuthClientKeyFactory {
      * @param masterSecretKey Master Key Secret
      * @return List with keys constructed from master secret that are needed to
      *         get requested signature type.
+     * @throws GenericCryptoException In case key derivation fails.
      */
-    public List<SecretKey> keysForSignatureType(PowerAuthSignatureTypes signatureType, SecretKey masterSecretKey) {
+    public List<SecretKey> keysForSignatureType(PowerAuthSignatureTypes signatureType, SecretKey masterSecretKey) throws GenericCryptoException {
 
         List<SecretKey> signatureKeys = new ArrayList<>();
 
@@ -150,8 +152,9 @@ public class PowerAuthClientKeyFactory {
      * @return Computed symmetric key KEY_MASTER_SECRET.
      * @throws InvalidKeyException
      *             In case some provided key is invalid.
+     * @throws GenericCryptoException In case shared key computation fails.
      */
-    public SecretKey generateClientMasterSecretKey(PrivateKey devicePrivateKey, PublicKey serverPublicKey) throws InvalidKeyException {
+    public SecretKey generateClientMasterSecretKey(PrivateKey devicePrivateKey, PublicKey serverPublicKey) throws InvalidKeyException, GenericCryptoException {
         return keyGenerator.computeSharedKey(devicePrivateKey, serverPublicKey);
     }
 
@@ -163,8 +166,9 @@ public class PowerAuthClientKeyFactory {
      * @param masterSecretKey
      *            Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_BIOMETRY.
+     * @throws GenericCryptoException In case key derivation fails.
      */
-    public SecretKey generateClientSignatureBiometryKey(SecretKey masterSecretKey) {
+    public SecretKey generateClientSignatureBiometryKey(SecretKey masterSecretKey) throws GenericCryptoException {
         return keyGenerator.deriveSecretKey(masterSecretKey, PowerAuthDerivedKey.SIGNATURE_BIOMETRY.getIndex());
     }
 
@@ -176,8 +180,9 @@ public class PowerAuthClientKeyFactory {
      * @param masterSecretKey
      *            Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_KNOWLEDGE.
+     * @throws GenericCryptoException In case key derivation fails.
      */
-    public SecretKey generateClientSignatureKnowledgeKey(SecretKey masterSecretKey) {
+    public SecretKey generateClientSignatureKnowledgeKey(SecretKey masterSecretKey) throws GenericCryptoException {
         return keyGenerator.deriveSecretKey(masterSecretKey, PowerAuthDerivedKey.SIGNATURE_KNOWLEDGE.getIndex());
     }
 
@@ -189,8 +194,9 @@ public class PowerAuthClientKeyFactory {
      * @param masterSecretKey
      *            Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_POSSESSION.
+     * @throws GenericCryptoException In case key derivation fails.
      */
-    public SecretKey generateClientSignaturePossessionKey(SecretKey masterSecretKey) {
+    public SecretKey generateClientSignaturePossessionKey(SecretKey masterSecretKey) throws GenericCryptoException {
         return keyGenerator.deriveSecretKey(masterSecretKey, PowerAuthDerivedKey.SIGNATURE_POSSESSION.getIndex());
     }
 
@@ -202,8 +208,9 @@ public class PowerAuthClientKeyFactory {
      * @param masterSecretKey
      *            Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_ENCRYPTED_VAULT.
+     * @throws GenericCryptoException In case key derivation fails.
      */
-    public SecretKey generateServerEncryptedVaultKey(SecretKey masterSecretKey) {
+    public SecretKey generateServerEncryptedVaultKey(SecretKey masterSecretKey) throws GenericCryptoException {
         return keyGenerator.deriveSecretKey(masterSecretKey, PowerAuthDerivedKey.ENCRYPTED_VAULT.getIndex());
     }
 
@@ -215,8 +222,9 @@ public class PowerAuthClientKeyFactory {
      * @param masterSecretKey
      *            Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_TRANSPORT.
+     * @throws GenericCryptoException In case key derivation fails.
      */
-    public SecretKey generateServerTransportKey(SecretKey masterSecretKey) {
+    public SecretKey generateServerTransportKey(SecretKey masterSecretKey) throws GenericCryptoException {
         return keyGenerator.deriveSecretKey(masterSecretKey, PowerAuthDerivedKey.TRANSPORT.getIndex());
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/keyfactory/PowerAuthClientKeyFactory.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/keyfactory/PowerAuthClientKeyFactory.java
@@ -92,10 +92,11 @@ public class PowerAuthClientKeyFactory {
      * @param masterSecretKey Master Key Secret
      * @return List with keys constructed from master secret that are needed to
      *         get requested signature type.
+     * @throws InvalidKeyException In case master secret key is invalid.
      * @throws GenericCryptoException In case key derivation fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public List<SecretKey> keysForSignatureType(PowerAuthSignatureTypes signatureType, SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
+    public List<SecretKey> keysForSignatureType(PowerAuthSignatureTypes signatureType, SecretKey masterSecretKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
 
         List<SecretKey> signatureKeys = new ArrayList<>();
 
@@ -168,10 +169,11 @@ public class PowerAuthClientKeyFactory {
      * @param masterSecretKey
      *            Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_BIOMETRY.
+     * @throws InvalidKeyException In case master secret key is invalid.
      * @throws GenericCryptoException In case key derivation fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateClientSignatureBiometryKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
+    public SecretKey generateClientSignatureBiometryKey(SecretKey masterSecretKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(masterSecretKey, PowerAuthDerivedKey.SIGNATURE_BIOMETRY.getIndex());
     }
 
@@ -183,10 +185,11 @@ public class PowerAuthClientKeyFactory {
      * @param masterSecretKey
      *            Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_KNOWLEDGE.
+     * @throws InvalidKeyException In case master secret key is invalid.
      * @throws GenericCryptoException In case key derivation fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateClientSignatureKnowledgeKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
+    public SecretKey generateClientSignatureKnowledgeKey(SecretKey masterSecretKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(masterSecretKey, PowerAuthDerivedKey.SIGNATURE_KNOWLEDGE.getIndex());
     }
 
@@ -198,10 +201,11 @@ public class PowerAuthClientKeyFactory {
      * @param masterSecretKey
      *            Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_POSSESSION.
+     * @throws InvalidKeyException In case master secret key is invalid.
      * @throws GenericCryptoException In case key derivation fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateClientSignaturePossessionKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
+    public SecretKey generateClientSignaturePossessionKey(SecretKey masterSecretKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(masterSecretKey, PowerAuthDerivedKey.SIGNATURE_POSSESSION.getIndex());
     }
 
@@ -213,10 +217,11 @@ public class PowerAuthClientKeyFactory {
      * @param masterSecretKey
      *            Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_ENCRYPTED_VAULT.
+     * @throws InvalidKeyException In case master secret key is invalid.
      * @throws GenericCryptoException In case key derivation fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateServerEncryptedVaultKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
+    public SecretKey generateServerEncryptedVaultKey(SecretKey masterSecretKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(masterSecretKey, PowerAuthDerivedKey.ENCRYPTED_VAULT.getIndex());
     }
 
@@ -228,10 +233,11 @@ public class PowerAuthClientKeyFactory {
      * @param masterSecretKey
      *            Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_TRANSPORT.
+     * @throws InvalidKeyException In case master secret key is invalid.
      * @throws GenericCryptoException In case key derivation fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateServerTransportKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
+    public SecretKey generateServerTransportKey(SecretKey masterSecretKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(masterSecretKey, PowerAuthDerivedKey.TRANSPORT.getIndex());
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/signature/PowerAuthClientSignature.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/signature/PowerAuthClientSignature.java
@@ -18,6 +18,7 @@ package io.getlime.security.powerauth.crypto.client.signature;
 
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.SignatureUtils;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 import javax.crypto.SecretKey;
 import java.util.List;
@@ -44,8 +45,9 @@ public class PowerAuthClientSignature {
      * @param ctrData Hash based counter / index of the derived key KEY_DERIVED.
      * @return PowerAuth signature for given data.
      * @throws GenericCryptoException In case signature computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public String signatureForData(byte[] data, List<SecretKey> signatureKeys, byte[] ctrData) throws GenericCryptoException {
+    public String signatureForData(byte[] data, List<SecretKey> signatureKeys, byte[] ctrData) throws GenericCryptoException, CryptoProviderException {
         return signatureUtils.computePowerAuthSignature(data, signatureKeys, ctrData);
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/signature/PowerAuthClientSignature.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/signature/PowerAuthClientSignature.java
@@ -16,6 +16,7 @@
  */
 package io.getlime.security.powerauth.crypto.client.signature;
 
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.SignatureUtils;
 
 import javax.crypto.SecretKey;
@@ -42,8 +43,9 @@ public class PowerAuthClientSignature {
      * @param signatureKeys A signature keys.
      * @param ctrData Hash based counter / index of the derived key KEY_DERIVED.
      * @return PowerAuth signature for given data.
+     * @throws GenericCryptoException In case signature computation fails.
      */
-    public String signatureForData(byte[] data, List<SecretKey> signatureKeys, byte[] ctrData) {
+    public String signatureForData(byte[] data, List<SecretKey> signatureKeys, byte[] ctrData) throws GenericCryptoException {
         return signatureUtils.computePowerAuthSignature(data, signatureKeys, ctrData);
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/token/ClientTokenGenerator.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/token/ClientTokenGenerator.java
@@ -18,6 +18,7 @@ package io.getlime.security.powerauth.crypto.client.token;
 
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.TokenUtils;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 
 /**
@@ -56,8 +57,9 @@ public class ClientTokenGenerator {
      * @param tokenSecret Token secret, 16 random bytes.
      * @return Token digest computed using provided data bytes with given token secret.
      * @throws GenericCryptoException In case digest computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] computeTokenDigest(byte[] nonce, byte[] timestamp, byte[] tokenSecret) throws GenericCryptoException {
+    public byte[] computeTokenDigest(byte[] nonce, byte[] timestamp, byte[] tokenSecret) throws GenericCryptoException, CryptoProviderException {
         return tokenUtils.computeTokenDigest(nonce, timestamp, tokenSecret);
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/token/ClientTokenGenerator.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/token/ClientTokenGenerator.java
@@ -16,6 +16,7 @@
  */
 package io.getlime.security.powerauth.crypto.client.token;
 
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.TokenUtils;
 
 
@@ -54,8 +55,9 @@ public class ClientTokenGenerator {
      * @param timestamp Token timestamp, Unix timestamp format encoded as bytes (from string representation).
      * @param tokenSecret Token secret, 16 random bytes.
      * @return Token digest computed using provided data bytes with given token secret.
+     * @throws GenericCryptoException In case digest computation fails.
      */
-    public byte[] computeTokenDigest(byte[] nonce, byte[] timestamp, byte[] tokenSecret) {
+    public byte[] computeTokenDigest(byte[] nonce, byte[] timestamp, byte[] tokenSecret) throws GenericCryptoException {
         return tokenUtils.computeTokenDigest(nonce, timestamp, tokenSecret);
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/vault/PowerAuthClientVault.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/vault/PowerAuthClientVault.java
@@ -128,15 +128,16 @@ public class PowerAuthClientVault {
      * @return Original private key.
      * @throws InvalidKeyException In case invalid key is provided.
      * @throws GenericCryptoException In case decryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public PrivateKey decryptDevicePrivateKey(byte[] cDevicePrivateKey, SecretKey vaultEncryptionKey) throws InvalidKeyException, GenericCryptoException {
+    public PrivateKey decryptDevicePrivateKey(byte[] cDevicePrivateKey, SecretKey vaultEncryptionKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         AESEncryptionUtils aes = new AESEncryptionUtils();
         CryptoProviderUtil keyConvertor = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
         byte[] zeroBytes = new byte[16];
         try {
             byte[] keyBytes = aes.decrypt(cDevicePrivateKey, zeroBytes, vaultEncryptionKey);
             return keyConvertor.convertBytesToPrivateKey(keyBytes);
-        } catch (IllegalBlockSizeException | BadPaddingException | InvalidKeySpecException | CryptoProviderException ex) {
+        } catch (IllegalBlockSizeException | BadPaddingException | InvalidKeySpecException ex) {
             throw new GenericCryptoException(ex.getMessage(), ex);
         }
     }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/vault/PowerAuthClientVault.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/vault/PowerAuthClientVault.java
@@ -55,8 +55,9 @@ public class PowerAuthClientVault {
      * @return Original KEY_ENCRYPTION_VAULT
      * @throws InvalidKeyException In case invalid key is provided.
      * @throws GenericCryptoException In case decryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey decryptVaultEncryptionKey(byte[] cVaultEncryptionKey, SecretKey masterTransportKey, byte[] ctr) throws InvalidKeyException, GenericCryptoException {
+    public SecretKey decryptVaultEncryptionKey(byte[] cVaultEncryptionKey, SecretKey masterTransportKey, byte[] ctr) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         AESEncryptionUtils aes = new AESEncryptionUtils();
         CryptoProviderUtil keyConvertor = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
         KeyGenerator keyGen = new KeyGenerator();
@@ -83,8 +84,9 @@ public class PowerAuthClientVault {
      * @return Original KEY_ENCRYPTION_VAULT
      * @throws InvalidKeyException In case invalid key is provided.
      * @throws GenericCryptoException In case decryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey decryptVaultEncryptionKey(byte[] cVaultEncryptionKey, SecretKey transportKey) throws InvalidKeyException, GenericCryptoException {
+    public SecretKey decryptVaultEncryptionKey(byte[] cVaultEncryptionKey, SecretKey transportKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         AESEncryptionUtils aes = new AESEncryptionUtils();
         CryptoProviderUtil keyConvertor = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
         byte[] zeroBytes = new byte[16];
@@ -104,8 +106,9 @@ public class PowerAuthClientVault {
      * @return Encrypted private key.
      * @throws InvalidKeyException In case invalid key is provided.
      * @throws GenericCryptoException In case encryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] encryptDevicePrivateKey(PrivateKey devicePrivateKey, SecretKey vaultEncryptionKey) throws InvalidKeyException, GenericCryptoException {
+    public byte[] encryptDevicePrivateKey(PrivateKey devicePrivateKey, SecretKey vaultEncryptionKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         try {
             AESEncryptionUtils aes = new AESEncryptionUtils();
             CryptoProviderUtil keyConvertor = PowerAuthConfiguration.INSTANCE.getKeyConvertor();

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/vault/PowerAuthClientVault.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/vault/PowerAuthClientVault.java
@@ -23,8 +23,6 @@ import io.getlime.security.powerauth.crypto.lib.util.AESEncryptionUtils;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
-import javax.crypto.BadPaddingException;
-import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
 import java.security.PrivateKey;
@@ -63,12 +61,8 @@ public class PowerAuthClientVault {
         KeyGenerator keyGen = new KeyGenerator();
         SecretKey vaultEncryptionTransportKey = keyGen.deriveSecretKey(masterTransportKey, ctr);
         byte[] zeroBytes = new byte[16];
-        try {
-            byte[] keyBytes = aes.decrypt(cVaultEncryptionKey, zeroBytes, vaultEncryptionTransportKey);
-            return keyConvertor.convertBytesToSharedSecretKey(keyBytes);
-        } catch (IllegalBlockSizeException | BadPaddingException ex) {
-            throw new GenericCryptoException(ex.getMessage(), ex);
-        }
+        byte[] keyBytes = aes.decrypt(cVaultEncryptionKey, zeroBytes, vaultEncryptionTransportKey);
+        return keyConvertor.convertBytesToSharedSecretKey(keyBytes);
     }
 
     /**
@@ -90,12 +84,8 @@ public class PowerAuthClientVault {
         AESEncryptionUtils aes = new AESEncryptionUtils();
         CryptoProviderUtil keyConvertor = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
         byte[] zeroBytes = new byte[16];
-        try {
-            byte[] keyBytes = aes.decrypt(cVaultEncryptionKey, zeroBytes, transportKey);
-            return keyConvertor.convertBytesToSharedSecretKey(keyBytes);
-        } catch (IllegalBlockSizeException | BadPaddingException ex) {
-            throw new GenericCryptoException(ex.getMessage(), ex);
-        }
+        byte[] keyBytes = aes.decrypt(cVaultEncryptionKey, zeroBytes, transportKey);
+        return keyConvertor.convertBytesToSharedSecretKey(keyBytes);
     }
 
     /**
@@ -109,15 +99,11 @@ public class PowerAuthClientVault {
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
     public byte[] encryptDevicePrivateKey(PrivateKey devicePrivateKey, SecretKey vaultEncryptionKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
-        try {
-            AESEncryptionUtils aes = new AESEncryptionUtils();
-            CryptoProviderUtil keyConvertor = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
-            byte[] devicePrivateKeyBytes = keyConvertor.convertPrivateKeyToBytes(devicePrivateKey);
-            byte[] zeroBytes = new byte[16];
-            return aes.encrypt(devicePrivateKeyBytes, zeroBytes, vaultEncryptionKey);
-        } catch (IllegalBlockSizeException | BadPaddingException ex) {
-            throw new GenericCryptoException(ex.getMessage(), ex);
-        }
+        AESEncryptionUtils aes = new AESEncryptionUtils();
+        CryptoProviderUtil keyConvertor = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
+        byte[] devicePrivateKeyBytes = keyConvertor.convertPrivateKeyToBytes(devicePrivateKey);
+        byte[] zeroBytes = new byte[16];
+        return aes.encrypt(devicePrivateKeyBytes, zeroBytes, vaultEncryptionKey);
     }
 
     /**
@@ -127,19 +113,16 @@ public class PowerAuthClientVault {
      * @param vaultEncryptionKey Vault encryption key KEY_ENCRYPTION_VAULT.
      * @return Original private key.
      * @throws InvalidKeyException In case invalid key is provided.
+     * @throws InvalidKeySpecException In case key spec is invalid.
      * @throws GenericCryptoException In case decryption fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public PrivateKey decryptDevicePrivateKey(byte[] cDevicePrivateKey, SecretKey vaultEncryptionKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
+    public PrivateKey decryptDevicePrivateKey(byte[] cDevicePrivateKey, SecretKey vaultEncryptionKey) throws InvalidKeyException, InvalidKeySpecException, GenericCryptoException, CryptoProviderException {
         AESEncryptionUtils aes = new AESEncryptionUtils();
         CryptoProviderUtil keyConvertor = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
         byte[] zeroBytes = new byte[16];
-        try {
-            byte[] keyBytes = aes.decrypt(cDevicePrivateKey, zeroBytes, vaultEncryptionKey);
-            return keyConvertor.convertBytesToPrivateKey(keyBytes);
-        } catch (IllegalBlockSizeException | BadPaddingException | InvalidKeySpecException ex) {
-            throw new GenericCryptoException(ex.getMessage(), ex);
-        }
+        byte[] keyBytes = aes.decrypt(cDevicePrivateKey, zeroBytes, vaultEncryptionKey);
+        return keyConvertor.convertBytesToPrivateKey(keyBytes);
     }
 
 }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/NonPersonalizedEncryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/NonPersonalizedEncryptor.java
@@ -25,8 +25,6 @@ import io.getlime.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
-import javax.crypto.BadPaddingException;
-import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
 import java.util.Arrays;
@@ -70,89 +68,82 @@ public class NonPersonalizedEncryptor {
      * Encrypt original data using components in this encryptor.
      * @param originalData Data to be encrypted.
      * @return Message object with encrypted data.
+     * @throws InvalidKeyException In case encryption key is invalid.
      * @throws GenericCryptoException In case encryption fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public NonPersonalizedEncryptedMessage encrypt(byte[] originalData) throws GenericCryptoException, CryptoProviderException {
-        try {
-            byte[] adHocIndex = generator.generateRandomBytes(16);
-            byte[] macIndex = generator.generateRandomBytes(16);
+    public NonPersonalizedEncryptedMessage encrypt(byte[] originalData) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
+        byte[] adHocIndex = generator.generateRandomBytes(16);
+        byte[] macIndex = generator.generateRandomBytes(16);
 
-            // make sure the indexes are different
-            int attemptCount = 0;
-            while (Arrays.equals(adHocIndex, macIndex)) {
-                macIndex = generator.generateRandomBytes(16);
-                if (attemptCount < MAX_ATTEMPT_COUNT) { // make sure that there is no issue with random data generator
-                    attemptCount++;
-                } else {
-                    return null;
-                }
+        // make sure the indexes are different
+        int attemptCount = 0;
+        while (Arrays.equals(adHocIndex, macIndex)) {
+            macIndex = generator.generateRandomBytes(16);
+            if (attemptCount < MAX_ATTEMPT_COUNT) { // make sure that there is no issue with random data generator
+                attemptCount++;
+            } else {
+                return null;
             }
-
-            byte[] nonce = generator.generateRandomBytes(16);
-
-            SecretKey sessionKey = keyConversion.convertBytesToSharedSecretKey(this.sessionRelatedSecretKey);
-            SecretKey encryptionKey = generator.deriveSecretKeyHmac(sessionKey, adHocIndex);
-            SecretKey macKey = generator.deriveSecretKeyHmac(sessionKey, macIndex);
-
-            byte[] encryptedData = aes.encrypt(originalData, nonce, encryptionKey);
-            byte[] mac = hmac.hash(macKey, encryptedData);
-
-            NonPersonalizedEncryptedMessage message = new NonPersonalizedEncryptedMessage();
-            message.setApplicationKey(applicationKey);
-            message.setEphemeralPublicKey(ephemeralPublicKey);
-            message.setSessionIndex(sessionIndex);
-            message.setAdHocIndex(adHocIndex);
-            message.setMacIndex(macIndex);
-            message.setNonce(nonce);
-            message.setEncryptedData(encryptedData);
-            message.setMac(mac);
-
-            return message;
-        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException ex) {
-            throw new GenericCryptoException(ex.getMessage(), ex);
         }
+
+        byte[] nonce = generator.generateRandomBytes(16);
+
+        SecretKey sessionKey = keyConversion.convertBytesToSharedSecretKey(this.sessionRelatedSecretKey);
+        SecretKey encryptionKey = generator.deriveSecretKeyHmac(sessionKey, adHocIndex);
+        SecretKey macKey = generator.deriveSecretKeyHmac(sessionKey, macIndex);
+
+        byte[] encryptedData = aes.encrypt(originalData, nonce, encryptionKey);
+        byte[] mac = hmac.hash(macKey, encryptedData);
+
+        NonPersonalizedEncryptedMessage message = new NonPersonalizedEncryptedMessage();
+        message.setApplicationKey(applicationKey);
+        message.setEphemeralPublicKey(ephemeralPublicKey);
+        message.setSessionIndex(sessionIndex);
+        message.setAdHocIndex(adHocIndex);
+        message.setMacIndex(macIndex);
+        message.setNonce(nonce);
+        message.setEncryptedData(encryptedData);
+        message.setMac(mac);
+
+        return message;
     }
 
     /**
      * Decrypt the encrypted message from the message payload using this encryptor.
      * @param message Message object to be decrypted.
      * @return Original decrypted bytes.
+     * @throws InvalidKeyException In case decryption key is invalid.
      * @throws GenericCryptoException In case decryption fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] decrypt(NonPersonalizedEncryptedMessage message) throws GenericCryptoException, CryptoProviderException {
+    public byte[] decrypt(NonPersonalizedEncryptedMessage message) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
 
-        try {
-            byte[] adHocIndex = message.getAdHocIndex();
-            byte[] macIndex = message.getMacIndex();
+        byte[] adHocIndex = message.getAdHocIndex();
+        byte[] macIndex = message.getMacIndex();
 
-            // make sure the indexes are different
-            if (Arrays.equals(adHocIndex, macIndex)) {
-                return null;
-            }
-
-            byte[] nonce = message.getNonce();
-
-            SecretKey sessionKey = keyConversion.convertBytesToSharedSecretKey(this.sessionRelatedSecretKey);
-            SecretKey encryptionKey = generator.deriveSecretKeyHmac(sessionKey, adHocIndex);
-            SecretKey macKey = generator.deriveSecretKeyHmac(sessionKey, macIndex);
-
-            byte[] encryptedData = message.getEncryptedData();
-
-            byte[] macExpected = hmac.hash(macKey, encryptedData);
-            byte[] mac = message.getMac();
-
-            // make sure the macs are the same
-            if (!Arrays.equals(mac, macExpected)) {
-                return null;
-            }
-
-            return aes.decrypt(encryptedData, nonce, encryptionKey);
-
-        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException ex) {
-            throw new GenericCryptoException(ex.getMessage(), ex);
+        // make sure the indexes are different
+        if (Arrays.equals(adHocIndex, macIndex)) {
+            return null;
         }
+
+        byte[] nonce = message.getNonce();
+
+        SecretKey sessionKey = keyConversion.convertBytesToSharedSecretKey(this.sessionRelatedSecretKey);
+        SecretKey encryptionKey = generator.deriveSecretKeyHmac(sessionKey, adHocIndex);
+        SecretKey macKey = generator.deriveSecretKeyHmac(sessionKey, macIndex);
+
+        byte[] encryptedData = message.getEncryptedData();
+
+        byte[] macExpected = hmac.hash(macKey, encryptedData);
+        byte[] mac = message.getMac();
+
+        // make sure the macs are the same
+        if (!Arrays.equals(mac, macExpected)) {
+            return null;
+        }
+
+        return aes.decrypt(encryptedData, nonce, encryptionKey);
     }
 
     public byte[] getApplicationKey() {

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/NonPersonalizedEncryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/NonPersonalizedEncryptor.java
@@ -23,6 +23,7 @@ import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoExc
 import io.getlime.security.powerauth.crypto.lib.util.AESEncryptionUtils;
 import io.getlime.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
@@ -107,7 +108,7 @@ public class NonPersonalizedEncryptor {
             message.setMac(mac);
 
             return message;
-        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException ex) {
+        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException | CryptoProviderException ex) {
             throw new GenericCryptoException(ex.getMessage(), ex);
         }
     }
@@ -147,7 +148,7 @@ public class NonPersonalizedEncryptor {
 
             return aes.decrypt(encryptedData, nonce, encryptionKey);
 
-        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException ex) {
+        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException | CryptoProviderException ex) {
             throw new GenericCryptoException(ex.getMessage(), ex);
         }
     }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/NonPersonalizedEncryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/NonPersonalizedEncryptor.java
@@ -19,6 +19,7 @@ package io.getlime.security.powerauth.crypto.lib.encryptor;
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.encryptor.model.NonPersonalizedEncryptedMessage;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.AESEncryptionUtils;
 import io.getlime.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
@@ -28,8 +29,6 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
 import java.util.Arrays;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Class responsible for encrypting / decrypting data using non-personalized encryption
@@ -70,8 +69,9 @@ public class NonPersonalizedEncryptor {
      * Encrypt original data using components in this encryptor.
      * @param originalData Data to be encrypted.
      * @return Message object with encrypted data.
+     * @throws GenericCryptoException In case encryption fails.
      */
-    public NonPersonalizedEncryptedMessage encrypt(byte[] originalData) {
+    public NonPersonalizedEncryptedMessage encrypt(byte[] originalData) throws GenericCryptoException {
         try {
             byte[] adHocIndex = generator.generateRandomBytes(16);
             byte[] macIndex = generator.generateRandomBytes(16);
@@ -108,17 +108,17 @@ public class NonPersonalizedEncryptor {
 
             return message;
         } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException ex) {
-            Logger.getLogger(NonPersonalizedEncryptor.class.getName()).log(Level.SEVERE, null, ex);
+            throw new GenericCryptoException(ex.getMessage(), ex);
         }
-        return null;
     }
 
     /**
      * Decrypt the encrypted message from the message payload using this encryptor.
      * @param message Message object to be decrypted.
      * @return Original decrypted bytes.
+     * @throws GenericCryptoException In case decryption fails.
      */
-    public byte[] decrypt(NonPersonalizedEncryptedMessage message) {
+    public byte[] decrypt(NonPersonalizedEncryptedMessage message) throws GenericCryptoException {
 
         try {
             byte[] adHocIndex = message.getAdHocIndex();
@@ -148,9 +148,8 @@ public class NonPersonalizedEncryptor {
             return aes.decrypt(encryptedData, nonce, encryptionKey);
 
         } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException ex) {
-            Logger.getLogger(NonPersonalizedEncryptor.class.getName()).log(Level.SEVERE, null, ex);
+            throw new GenericCryptoException(ex.getMessage(), ex);
         }
-        return null;
     }
 
     public byte[] getApplicationKey() {

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/NonPersonalizedEncryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/NonPersonalizedEncryptor.java
@@ -71,8 +71,9 @@ public class NonPersonalizedEncryptor {
      * @param originalData Data to be encrypted.
      * @return Message object with encrypted data.
      * @throws GenericCryptoException In case encryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public NonPersonalizedEncryptedMessage encrypt(byte[] originalData) throws GenericCryptoException {
+    public NonPersonalizedEncryptedMessage encrypt(byte[] originalData) throws GenericCryptoException, CryptoProviderException {
         try {
             byte[] adHocIndex = generator.generateRandomBytes(16);
             byte[] macIndex = generator.generateRandomBytes(16);
@@ -108,7 +109,7 @@ public class NonPersonalizedEncryptor {
             message.setMac(mac);
 
             return message;
-        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException | CryptoProviderException ex) {
+        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException ex) {
             throw new GenericCryptoException(ex.getMessage(), ex);
         }
     }
@@ -118,8 +119,9 @@ public class NonPersonalizedEncryptor {
      * @param message Message object to be decrypted.
      * @return Original decrypted bytes.
      * @throws GenericCryptoException In case decryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] decrypt(NonPersonalizedEncryptedMessage message) throws GenericCryptoException {
+    public byte[] decrypt(NonPersonalizedEncryptedMessage message) throws GenericCryptoException, CryptoProviderException {
 
         try {
             byte[] adHocIndex = message.getAdHocIndex();
@@ -148,7 +150,7 @@ public class NonPersonalizedEncryptor {
 
             return aes.decrypt(encryptedData, nonce, encryptionKey);
 
-        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException | CryptoProviderException ex) {
+        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException ex) {
             throw new GenericCryptoException(ex.getMessage(), ex);
         }
     }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/NonPersonalizedEncryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/NonPersonalizedEncryptor.java
@@ -83,7 +83,7 @@ public class NonPersonalizedEncryptor {
             if (attemptCount < MAX_ATTEMPT_COUNT) { // make sure that there is no issue with random data generator
                 attemptCount++;
             } else {
-                return null;
+                throw new GenericCryptoException("Random byte array generation failed");
             }
         }
 
@@ -124,7 +124,7 @@ public class NonPersonalizedEncryptor {
 
         // make sure the indexes are different
         if (Arrays.equals(adHocIndex, macIndex)) {
-            return null;
+            throw new GenericCryptoException("Invalid index");
         }
 
         byte[] nonce = message.getNonce();
@@ -140,7 +140,7 @@ public class NonPersonalizedEncryptor {
 
         // make sure the macs are the same
         if (!Arrays.equals(mac, macExpected)) {
-            return null;
+            throw new GenericCryptoException("Invalid mac");
         }
 
         return aes.decrypt(encryptedData, nonce, encryptionKey);

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesDecryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesDecryptor.java
@@ -20,6 +20,7 @@ import com.google.common.primitives.Bytes;
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.exception.EciesException;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesCryptogram;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.AESEncryptionUtils;
 import io.getlime.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
@@ -206,8 +207,8 @@ public class EciesDecryptor {
             canEncryptData = true;
 
             return aes.decrypt(cryptogram.getEncryptedData(), iv, encKey);
-        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException e) {
-            throw new EciesException("Decryption error occurred", e);
+        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException | GenericCryptoException ex) {
+            throw new EciesException("Request decryption failed", ex);
         }
     }
 
@@ -236,8 +237,8 @@ public class EciesDecryptor {
 
             // Return encrypted payload
             return new EciesCryptogram(envelopeKey.getEphemeralKeyPublic(), mac, body);
-        } catch (InvalidKeyException | BadPaddingException | IllegalBlockSizeException e) {
-            throw new EciesException("Encryption error occurred", e);
+        } catch (InvalidKeyException | BadPaddingException | IllegalBlockSizeException | GenericCryptoException ex) {
+            throw new EciesException("Response encryption failed", ex);
         }
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesDecryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesDecryptor.java
@@ -24,6 +24,7 @@ import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoExc
 import io.getlime.security.powerauth.crypto.lib.util.AESEncryptionUtils;
 import io.getlime.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
@@ -207,7 +208,7 @@ public class EciesDecryptor {
             canEncryptData = true;
 
             return aes.decrypt(cryptogram.getEncryptedData(), iv, encKey);
-        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException | GenericCryptoException ex) {
+        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException | GenericCryptoException | CryptoProviderException ex) {
             throw new EciesException("Request decryption failed", ex);
         }
     }
@@ -237,7 +238,7 @@ public class EciesDecryptor {
 
             // Return encrypted payload
             return new EciesCryptogram(envelopeKey.getEphemeralKeyPublic(), mac, body);
-        } catch (InvalidKeyException | BadPaddingException | IllegalBlockSizeException | GenericCryptoException ex) {
+        } catch (InvalidKeyException | BadPaddingException | IllegalBlockSizeException | GenericCryptoException | CryptoProviderException ex) {
             throw new EciesException("Response encryption failed", ex);
         }
     }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesDecryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesDecryptor.java
@@ -26,8 +26,6 @@ import io.getlime.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
-import javax.crypto.BadPaddingException;
-import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
 import java.security.PrivateKey;
@@ -208,7 +206,7 @@ public class EciesDecryptor {
             canEncryptData = true;
 
             return aes.decrypt(cryptogram.getEncryptedData(), iv, encKey);
-        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException | GenericCryptoException | CryptoProviderException ex) {
+        } catch (InvalidKeyException | GenericCryptoException | CryptoProviderException ex) {
             throw new EciesException("Request decryption failed", ex);
         }
     }
@@ -238,7 +236,7 @@ public class EciesDecryptor {
 
             // Return encrypted payload
             return new EciesCryptogram(envelopeKey.getEphemeralKeyPublic(), mac, body);
-        } catch (InvalidKeyException | BadPaddingException | IllegalBlockSizeException | GenericCryptoException | CryptoProviderException ex) {
+        } catch (InvalidKeyException | GenericCryptoException | CryptoProviderException ex) {
             throw new EciesException("Response encryption failed", ex);
         }
     }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesEncryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesEncryptor.java
@@ -26,8 +26,6 @@ import io.getlime.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
-import javax.crypto.BadPaddingException;
-import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
 import java.security.PublicKey;
@@ -188,7 +186,7 @@ public class EciesEncryptor {
 
             // Return encrypted payload
             return new EciesCryptogram(envelopeKey.getEphemeralKeyPublic(), mac, encryptedData);
-        } catch (InvalidKeyException | BadPaddingException | IllegalBlockSizeException | GenericCryptoException | CryptoProviderException ex) {
+        } catch (InvalidKeyException | GenericCryptoException | CryptoProviderException ex) {
             throw new EciesException("Request encryption failed", ex);
         }
     }
@@ -219,7 +217,7 @@ public class EciesEncryptor {
             canDecryptData = false;
 
             return aes.decrypt(cryptogram.getEncryptedData(), iv, encKey);
-        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException | GenericCryptoException | CryptoProviderException ex) {
+        } catch (InvalidKeyException | GenericCryptoException | CryptoProviderException ex) {
             throw new EciesException("Response decryption failed", ex);
         }
     }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesEncryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesEncryptor.java
@@ -20,6 +20,7 @@ import com.google.common.primitives.Bytes;
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.exception.EciesException;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesCryptogram;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.AESEncryptionUtils;
 import io.getlime.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
@@ -186,8 +187,8 @@ public class EciesEncryptor {
 
             // Return encrypted payload
             return new EciesCryptogram(envelopeKey.getEphemeralKeyPublic(), mac, encryptedData);
-        } catch (InvalidKeyException | BadPaddingException | IllegalBlockSizeException e) {
-            throw new EciesException("Request encryption failed");
+        } catch (InvalidKeyException | BadPaddingException | IllegalBlockSizeException | GenericCryptoException ex) {
+            throw new EciesException("Request encryption failed", ex);
         }
     }
 
@@ -217,8 +218,8 @@ public class EciesEncryptor {
             canDecryptData = false;
 
             return aes.decrypt(cryptogram.getEncryptedData(), iv, encKey);
-        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException e) {
-            throw new EciesException("Response decryption failed");
+        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException | GenericCryptoException ex) {
+            throw new EciesException("Response decryption failed", ex);
         }
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesEncryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesEncryptor.java
@@ -24,6 +24,7 @@ import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoExc
 import io.getlime.security.powerauth.crypto.lib.util.AESEncryptionUtils;
 import io.getlime.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
@@ -187,7 +188,7 @@ public class EciesEncryptor {
 
             // Return encrypted payload
             return new EciesCryptogram(envelopeKey.getEphemeralKeyPublic(), mac, encryptedData);
-        } catch (InvalidKeyException | BadPaddingException | IllegalBlockSizeException | GenericCryptoException ex) {
+        } catch (InvalidKeyException | BadPaddingException | IllegalBlockSizeException | GenericCryptoException | CryptoProviderException ex) {
             throw new EciesException("Request encryption failed", ex);
         }
     }
@@ -218,7 +219,7 @@ public class EciesEncryptor {
             canDecryptData = false;
 
             return aes.decrypt(cryptogram.getEncryptedData(), iv, encKey);
-        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException | GenericCryptoException ex) {
+        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException | GenericCryptoException | CryptoProviderException ex) {
             throw new EciesException("Response decryption failed", ex);
         }
     }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesEnvelopeKey.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesEnvelopeKey.java
@@ -21,6 +21,7 @@ import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.exception.EciesException;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.kdf.KdfX9_63;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
@@ -90,7 +91,7 @@ public class EciesEnvelopeKey {
 
             // Return envelope key with derived secret key and ephemeral public key bytes
             return new EciesEnvelopeKey(secretKey, ephemeralPublicKeyBytes);
-        } catch (InvalidKeyException | CryptoProviderException ex) {
+        } catch (InvalidKeyException | GenericCryptoException | CryptoProviderException ex) {
             throw new EciesException("Key derivation failed", ex);
         }
     }
@@ -120,7 +121,7 @@ public class EciesEnvelopeKey {
 
             // Return envelope key with derived secret key and ephemeral public key bytes
             return new EciesEnvelopeKey(secretKey, ephemeralPublicKeyBytes);
-        } catch (InvalidKeyException | InvalidKeySpecException | CryptoProviderException ex) {
+        } catch (InvalidKeyException | InvalidKeySpecException | GenericCryptoException | CryptoProviderException ex) {
             throw new EciesException("Key derivation failed", ex);
         }
     }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesEnvelopeKey.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesEnvelopeKey.java
@@ -21,7 +21,6 @@ import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.exception.EciesException;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.kdf.KdfX9_63;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
-import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
@@ -91,7 +90,7 @@ public class EciesEnvelopeKey {
 
             // Return envelope key with derived secret key and ephemeral public key bytes
             return new EciesEnvelopeKey(secretKey, ephemeralPublicKeyBytes);
-        } catch (InvalidKeyException | GenericCryptoException ex) {
+        } catch (InvalidKeyException | CryptoProviderException ex) {
             throw new EciesException("Key derivation failed", ex);
         }
     }
@@ -121,7 +120,7 @@ public class EciesEnvelopeKey {
 
             // Return envelope key with derived secret key and ephemeral public key bytes
             return new EciesEnvelopeKey(secretKey, ephemeralPublicKeyBytes);
-        } catch (InvalidKeyException | InvalidKeySpecException | GenericCryptoException | CryptoProviderException ex) {
+        } catch (InvalidKeyException | InvalidKeySpecException | CryptoProviderException ex) {
             throw new EciesException("Key derivation failed", ex);
         }
     }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesEnvelopeKey.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesEnvelopeKey.java
@@ -21,7 +21,9 @@ import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.exception.EciesException;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.kdf.KdfX9_63;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 import javax.crypto.SecretKey;
 import java.nio.ByteBuffer;
@@ -89,8 +91,8 @@ public class EciesEnvelopeKey {
 
             // Return envelope key with derived secret key and ephemeral public key bytes
             return new EciesEnvelopeKey(secretKey, ephemeralPublicKeyBytes);
-        } catch (InvalidKeyException ex) {
-            throw new EciesException("Key derivation failed");
+        } catch (InvalidKeyException | GenericCryptoException ex) {
+            throw new EciesException("Key derivation failed", ex);
         }
     }
 
@@ -119,8 +121,8 @@ public class EciesEnvelopeKey {
 
             // Return envelope key with derived secret key and ephemeral public key bytes
             return new EciesEnvelopeKey(secretKey, ephemeralPublicKeyBytes);
-        } catch (InvalidKeyException | InvalidKeySpecException ex) {
-            throw new EciesException("Key derivation failed");
+        } catch (InvalidKeyException | InvalidKeySpecException | GenericCryptoException | CryptoProviderException ex) {
+            throw new EciesException("Key derivation failed", ex);
         }
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesFactory.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesFactory.java
@@ -115,7 +115,6 @@ public class EciesFactory {
      * @param applicationSecret Application secret.
      * @return Initialized ECIES decryptor.
      * @throws GenericCryptoException In case decryptor could not be initialized.
-     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
     public EciesDecryptor getEciesDecryptorForApplication(ECPrivateKey privateKey, byte[] applicationSecret, EciesSharedInfo1 sharedInfo1) throws GenericCryptoException, CryptoProviderException {
         byte[] sharedInfo1Value = sharedInfo1 == null ? EciesSharedInfo1.APPLICATION_SCOPE_GENERIC.value() : sharedInfo1.value();

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesFactory.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesFactory.java
@@ -21,6 +21,7 @@ import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesShare
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import io.getlime.security.powerauth.crypto.lib.util.Hash;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
@@ -41,8 +42,9 @@ public class EciesFactory {
      * @param applicationSecret Application secret.
      * @return Initialized ECIES encryptor.
      * @throws GenericCryptoException In case encryptor could not be initialized.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public EciesEncryptor getEciesEncryptorForApplication(ECPublicKey publicKey, byte[] applicationSecret, EciesSharedInfo1 sharedInfo1) throws GenericCryptoException {
+    public EciesEncryptor getEciesEncryptorForApplication(ECPublicKey publicKey, byte[] applicationSecret, EciesSharedInfo1 sharedInfo1) throws GenericCryptoException, CryptoProviderException {
         byte[] sharedInfo1Value = sharedInfo1 == null ? EciesSharedInfo1.APPLICATION_SCOPE_GENERIC.value() : sharedInfo1.value();
         return getEciesEncryptor(EciesScope.APPLICATION_SCOPE, publicKey, applicationSecret, null, sharedInfo1Value);
     }
@@ -56,8 +58,9 @@ public class EciesFactory {
      * @param sharedInfo1 Additional information for sharedInfo1 parameter using pre-defined constants.
      * @return Initialized ECIES encryptor.
      * @throws GenericCryptoException In case encryptor could not be initialized.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public EciesEncryptor getEciesEncryptorForActivation(ECPublicKey publicKey, byte[] applicationSecret, byte[] transportKey, EciesSharedInfo1 sharedInfo1) throws GenericCryptoException {
+    public EciesEncryptor getEciesEncryptorForActivation(ECPublicKey publicKey, byte[] applicationSecret, byte[] transportKey, EciesSharedInfo1 sharedInfo1) throws GenericCryptoException, CryptoProviderException {
         byte[] sharedInfo1Value = sharedInfo1 == null ? EciesSharedInfo1.ACTIVATION_SCOPE_GENERIC.value() : sharedInfo1.value();
         return getEciesEncryptor(EciesScope.ACTIVATION_SCOPE, publicKey, applicationSecret, transportKey, sharedInfo1Value);
     }
@@ -83,8 +86,9 @@ public class EciesFactory {
      * @param sharedInfo1 Additional information for sharedInfo1 parameter in bytes.
      * @return Initialized ECIES encryptor.
      * @throws GenericCryptoException In case encryptor could not be initialized.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    private EciesEncryptor getEciesEncryptor(EciesScope eciesScope, ECPublicKey publicKey, byte[] applicationSecret, byte[] transportKey, byte[] sharedInfo1) throws GenericCryptoException {
+    private EciesEncryptor getEciesEncryptor(EciesScope eciesScope, ECPublicKey publicKey, byte[] applicationSecret, byte[] transportKey, byte[] sharedInfo1) throws GenericCryptoException, CryptoProviderException {
         switch (eciesScope) {
 
             case APPLICATION_SCOPE: {
@@ -110,9 +114,10 @@ public class EciesFactory {
      * @param privateKey Private key used for ECIES.
      * @param applicationSecret Application secret.
      * @return Initialized ECIES decryptor.
-     * @throws GenericCryptoException TIn case decryptor could not be initialized.
+     * @throws GenericCryptoException In case decryptor could not be initialized.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public EciesDecryptor getEciesDecryptorForApplication(ECPrivateKey privateKey, byte[] applicationSecret, EciesSharedInfo1 sharedInfo1) throws GenericCryptoException {
+    public EciesDecryptor getEciesDecryptorForApplication(ECPrivateKey privateKey, byte[] applicationSecret, EciesSharedInfo1 sharedInfo1) throws GenericCryptoException, CryptoProviderException {
         byte[] sharedInfo1Value = sharedInfo1 == null ? EciesSharedInfo1.APPLICATION_SCOPE_GENERIC.value() : sharedInfo1.value();
         return getEciesDecryptor(EciesScope.APPLICATION_SCOPE, privateKey, applicationSecret, null, sharedInfo1Value);
     }
@@ -126,8 +131,9 @@ public class EciesFactory {
      * @param sharedInfo1 Additional information for sharedInfo1 parameter using pre-defined constants.
      * @return Initialized ECIES decryptor.
      * @throws GenericCryptoException In case decryptor could not be initialized.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public EciesDecryptor getEciesDecryptorForActivation(ECPrivateKey privateKey, byte[] applicationSecret, byte[] transportKey, EciesSharedInfo1 sharedInfo1) throws GenericCryptoException {
+    public EciesDecryptor getEciesDecryptorForActivation(ECPrivateKey privateKey, byte[] applicationSecret, byte[] transportKey, EciesSharedInfo1 sharedInfo1) throws GenericCryptoException, CryptoProviderException {
         byte[] sharedInfo1Value = sharedInfo1 == null ? EciesSharedInfo1.ACTIVATION_SCOPE_GENERIC.value() : sharedInfo1.value();
         return getEciesDecryptor(EciesScope.ACTIVATION_SCOPE, privateKey, applicationSecret, transportKey, sharedInfo1Value);
     }
@@ -153,8 +159,9 @@ public class EciesFactory {
      * @param sharedInfo1 Additional information for sharedInfo1 parameter in bytes.
      * @return Initialized ECIES decryptor.
      * @throws GenericCryptoException In case decryptor could not be initialized.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    private EciesDecryptor getEciesDecryptor(EciesScope eciesScope, ECPrivateKey privateKey, byte[] applicationSecret, byte[] transportKey, byte[] sharedInfo1) throws GenericCryptoException {
+    private EciesDecryptor getEciesDecryptor(EciesScope eciesScope, ECPrivateKey privateKey, byte[] applicationSecret, byte[] transportKey, byte[] sharedInfo1) throws GenericCryptoException, CryptoProviderException {
         switch (eciesScope) {
 
             case APPLICATION_SCOPE: {

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesFactory.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesFactory.java
@@ -18,6 +18,7 @@ package io.getlime.security.powerauth.crypto.lib.encryptor.ecies;
 
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesScope;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesSharedInfo1;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import io.getlime.security.powerauth.crypto.lib.util.Hash;
 
@@ -39,8 +40,9 @@ public class EciesFactory {
      * @param publicKey Public key used for ECIES.
      * @param applicationSecret Application secret.
      * @return Initialized ECIES encryptor.
+     * @throws GenericCryptoException In case encryptor could not be initialized.
      */
-    public EciesEncryptor getEciesEncryptorForApplication(ECPublicKey publicKey, byte[] applicationSecret, EciesSharedInfo1 sharedInfo1) {
+    public EciesEncryptor getEciesEncryptorForApplication(ECPublicKey publicKey, byte[] applicationSecret, EciesSharedInfo1 sharedInfo1) throws GenericCryptoException {
         byte[] sharedInfo1Value = sharedInfo1 == null ? EciesSharedInfo1.APPLICATION_SCOPE_GENERIC.value() : sharedInfo1.value();
         return getEciesEncryptor(EciesScope.APPLICATION_SCOPE, publicKey, applicationSecret, null, sharedInfo1Value);
     }
@@ -53,8 +55,9 @@ public class EciesFactory {
      * @param transportKey Transport key.
      * @param sharedInfo1 Additional information for sharedInfo1 parameter using pre-defined constants.
      * @return Initialized ECIES encryptor.
+     * @throws GenericCryptoException In case encryptor could not be initialized.
      */
-    public EciesEncryptor getEciesEncryptorForActivation(ECPublicKey publicKey, byte[] applicationSecret, byte[] transportKey, EciesSharedInfo1 sharedInfo1) {
+    public EciesEncryptor getEciesEncryptorForActivation(ECPublicKey publicKey, byte[] applicationSecret, byte[] transportKey, EciesSharedInfo1 sharedInfo1) throws GenericCryptoException {
         byte[] sharedInfo1Value = sharedInfo1 == null ? EciesSharedInfo1.ACTIVATION_SCOPE_GENERIC.value() : sharedInfo1.value();
         return getEciesEncryptor(EciesScope.ACTIVATION_SCOPE, publicKey, applicationSecret, transportKey, sharedInfo1Value);
     }
@@ -79,8 +82,9 @@ public class EciesFactory {
      * @param transportKey Transport key for activation scope. Use null value for application scope.
      * @param sharedInfo1 Additional information for sharedInfo1 parameter in bytes.
      * @return Initialized ECIES encryptor.
+     * @throws GenericCryptoException In case encryptor could not be initialized.
      */
-    private EciesEncryptor getEciesEncryptor(EciesScope eciesScope, ECPublicKey publicKey, byte[] applicationSecret, byte[] transportKey, byte[] sharedInfo1) {
+    private EciesEncryptor getEciesEncryptor(EciesScope eciesScope, ECPublicKey publicKey, byte[] applicationSecret, byte[] transportKey, byte[] sharedInfo1) throws GenericCryptoException {
         switch (eciesScope) {
 
             case APPLICATION_SCOPE: {
@@ -96,7 +100,7 @@ public class EciesFactory {
             }
 
             default:
-                throw new IllegalStateException("Unsupported ECIES scope: "+eciesScope);
+                throw new GenericCryptoException("Unsupported ECIES scope: "+eciesScope);
         }
     }
 
@@ -106,8 +110,9 @@ public class EciesFactory {
      * @param privateKey Private key used for ECIES.
      * @param applicationSecret Application secret.
      * @return Initialized ECIES decryptor.
+     * @throws GenericCryptoException TIn case decryptor could not be initialized.
      */
-    public EciesDecryptor getEciesDecryptorForApplication(ECPrivateKey privateKey, byte[] applicationSecret, EciesSharedInfo1 sharedInfo1) {
+    public EciesDecryptor getEciesDecryptorForApplication(ECPrivateKey privateKey, byte[] applicationSecret, EciesSharedInfo1 sharedInfo1) throws GenericCryptoException {
         byte[] sharedInfo1Value = sharedInfo1 == null ? EciesSharedInfo1.APPLICATION_SCOPE_GENERIC.value() : sharedInfo1.value();
         return getEciesDecryptor(EciesScope.APPLICATION_SCOPE, privateKey, applicationSecret, null, sharedInfo1Value);
     }
@@ -120,8 +125,9 @@ public class EciesFactory {
      * @param transportKey Transport key.
      * @param sharedInfo1 Additional information for sharedInfo1 parameter using pre-defined constants.
      * @return Initialized ECIES decryptor.
+     * @throws GenericCryptoException In case decryptor could not be initialized.
      */
-    public EciesDecryptor getEciesDecryptorForActivation(ECPrivateKey privateKey, byte[] applicationSecret, byte[] transportKey, EciesSharedInfo1 sharedInfo1) {
+    public EciesDecryptor getEciesDecryptorForActivation(ECPrivateKey privateKey, byte[] applicationSecret, byte[] transportKey, EciesSharedInfo1 sharedInfo1) throws GenericCryptoException {
         byte[] sharedInfo1Value = sharedInfo1 == null ? EciesSharedInfo1.ACTIVATION_SCOPE_GENERIC.value() : sharedInfo1.value();
         return getEciesDecryptor(EciesScope.ACTIVATION_SCOPE, privateKey, applicationSecret, transportKey, sharedInfo1Value);
     }
@@ -146,8 +152,9 @@ public class EciesFactory {
      * @param transportKey Transport key for activation scope. Use null value for application scope.
      * @param sharedInfo1 Additional information for sharedInfo1 parameter in bytes.
      * @return Initialized ECIES decryptor.
+     * @throws GenericCryptoException In case decryptor could not be initialized.
      */
-    private EciesDecryptor getEciesDecryptor(EciesScope eciesScope, ECPrivateKey privateKey, byte[] applicationSecret, byte[] transportKey, byte[] sharedInfo1) {
+    private EciesDecryptor getEciesDecryptor(EciesScope eciesScope, ECPrivateKey privateKey, byte[] applicationSecret, byte[] transportKey, byte[] sharedInfo1) throws GenericCryptoException {
         switch (eciesScope) {
 
             case APPLICATION_SCOPE: {
@@ -163,7 +170,7 @@ public class EciesFactory {
             }
 
             default:
-                throw new IllegalStateException("Unsupported ECIES scope: "+eciesScope);
+                throw new GenericCryptoException("Unsupported ECIES scope: "+eciesScope);
         }
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/kdf/KdfX9_63.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/kdf/KdfX9_63.java
@@ -17,6 +17,7 @@
 package io.getlime.security.powerauth.crypto.lib.encryptor.ecies.kdf;
 
 import com.google.common.primitives.Bytes;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.Hash;
 
 import java.nio.ByteBuffer;
@@ -35,10 +36,11 @@ public class KdfX9_63 {
      * @param sharedInfo Extra information used for derived key computation.
      * @param outputBytes Requested size of the key.
      * @return Derived key using the X9.63 KDF with SHA256 digest.
+     * @throws GenericCryptoException In case key derivation fails.
      */
-    public static byte[] derive(byte[] secret, byte[] sharedInfo, int outputBytes) {
+    public static byte[] derive(byte[] secret, byte[] sharedInfo, int outputBytes) throws GenericCryptoException {
         if (secret == null) {
-            return null;
+            throw new GenericCryptoException("Missing secret for KDF X9.63");
         }
         byte[] result = new byte[0];
         byte[] round = new byte[secret.length + 4 + (sharedInfo == null ? 0 : sharedInfo.length)];

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/KeyGenerator.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/KeyGenerator.java
@@ -177,8 +177,9 @@ public class KeyGenerator {
      * @param index A byte array index of the key.
      * @return A new derived key from a master key with given index.
      * @throws GenericCryptoException In case key derivation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey deriveSecretKeyHmac(SecretKey secret, byte[] index) throws GenericCryptoException {
+    public SecretKey deriveSecretKeyHmac(SecretKey secret, byte[] index) throws GenericCryptoException, CryptoProviderException {
         CryptoProviderUtil keyConvertor = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
         byte[] secretKeyBytes = keyConvertor.convertSharedSecretKeyToBytes(secret);
         HMACHashUtilities hmac = new HMACHashUtilities();

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/KeyGenerator.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/KeyGenerator.java
@@ -23,7 +23,9 @@ import io.getlime.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
-import javax.crypto.*;
+import javax.crypto.KeyAgreement;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.*;
@@ -152,18 +154,15 @@ public class KeyGenerator {
      * @param secret A master shared key.
      * @param index A byte array index of the key.
      * @return A new derived key from a master key with given index.
+     * @throws InvalidKeyException In case secret key is invalid.
      * @throws GenericCryptoException In case key derivation fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey deriveSecretKey(SecretKey secret, byte[] index) throws GenericCryptoException, CryptoProviderException {
-        try {
-            AESEncryptionUtils aes = new AESEncryptionUtils();
-            byte[] iv = new byte[16];
-            byte[] encryptedBytes = aes.encrypt(index, iv, secret);
-            return PowerAuthConfiguration.INSTANCE.getKeyConvertor().convertBytesToSharedSecretKey(Arrays.copyOf(encryptedBytes, 16));
-        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException ex) {
-            throw new GenericCryptoException(ex.getMessage(), ex);
-        }
+    public SecretKey deriveSecretKey(SecretKey secret, byte[] index) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
+        AESEncryptionUtils aes = new AESEncryptionUtils();
+        byte[] iv = new byte[16];
+        byte[] encryptedBytes = aes.encrypt(index, iv, secret);
+        return PowerAuthConfiguration.INSTANCE.getKeyConvertor().convertBytesToSharedSecretKey(Arrays.copyOf(encryptedBytes, 16));
     }
 
     /**

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/exception/GenericCryptoException.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/exception/GenericCryptoException.java
@@ -1,0 +1,57 @@
+/*
+ * PowerAuth Crypto Library
+ * Copyright 2018 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.crypto.lib.model.exception;
+
+/**
+ * Exception used for handling unexpected states when using cryptography.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class GenericCryptoException extends Exception {
+
+    /**
+     * Default constructor.
+     */
+    public GenericCryptoException() {
+        super();
+    }
+
+    /**
+     * Exception with error message.
+     * @param message Error message.
+     */
+    public GenericCryptoException(String message) {
+        super(message);
+    }
+
+    /**
+     * Exception with error message and cause.
+     * @param message Error message.
+     * @param cause Exception cause.
+     */
+    public GenericCryptoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Exception with cause.
+     * @param cause Exception cause.
+     */
+    public GenericCryptoException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/AESEncryptionUtils.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/AESEncryptionUtils.java
@@ -55,9 +55,9 @@ public class AESEncryptionUtils {
             Cipher cipherForCryptoResponse = Cipher.getInstance(padding, PowerAuthConfiguration.INSTANCE.getKeyConvertor().getProviderName());
             cipherForCryptoResponse.init(Cipher.ENCRYPT_MODE, secret, new IvParameterSpec(iv));
             return cipherForCryptoResponse.doFinal(bytes);
-        } catch (NoSuchAlgorithmException | NoSuchProviderException ex) {
+        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException ex) {
             throw new CryptoProviderException(ex.getMessage(), ex);
-        } catch (NoSuchPaddingException | InvalidAlgorithmParameterException ex) {
+        } catch (NoSuchPaddingException ex) {
             throw new GenericCryptoException(ex.getMessage(), ex);
         }
     }
@@ -100,9 +100,9 @@ public class AESEncryptionUtils {
             Cipher cipherForCryptoResponse = Cipher.getInstance(padding, PowerAuthConfiguration.INSTANCE.getKeyConvertor().getProviderName());
             cipherForCryptoResponse.init(Cipher.DECRYPT_MODE, secret, new IvParameterSpec(iv));
             return cipherForCryptoResponse.doFinal(bytes);
-        } catch (NoSuchAlgorithmException | NoSuchProviderException ex) {
+        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException ex) {
             throw new CryptoProviderException(ex.getMessage(), ex);
-        } catch (NoSuchPaddingException | InvalidAlgorithmParameterException ex) {
+        } catch (NoSuchPaddingException ex) {
             throw new GenericCryptoException(ex.getMessage(), ex);
         }
     }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/AESEncryptionUtils.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/AESEncryptionUtils.java
@@ -18,6 +18,7 @@ package io.getlime.security.powerauth.crypto.lib.util;
 
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 import javax.crypto.*;
 import javax.crypto.spec.IvParameterSpec;
@@ -47,13 +48,16 @@ public class AESEncryptionUtils {
      * @throws IllegalBlockSizeException In case invalid key size is provided.
      * @throws BadPaddingException In case invalid padding is provided.
      * @throws GenericCryptoException In case encryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] encrypt(byte[] bytes, byte[] iv, SecretKey secret, String padding) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException, GenericCryptoException {
+    public byte[] encrypt(byte[] bytes, byte[] iv, SecretKey secret, String padding) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException, GenericCryptoException, CryptoProviderException {
         try {
             Cipher cipherForCryptoResponse = Cipher.getInstance(padding, PowerAuthConfiguration.INSTANCE.getKeyConvertor().getProviderName());
             cipherForCryptoResponse.init(Cipher.ENCRYPT_MODE, secret, new IvParameterSpec(iv));
             return cipherForCryptoResponse.doFinal(bytes);
-        } catch (NoSuchAlgorithmException | NoSuchProviderException | NoSuchPaddingException | InvalidAlgorithmParameterException ex) {
+        } catch (NoSuchAlgorithmException | NoSuchProviderException ex) {
+            throw new CryptoProviderException(ex.getMessage(), ex);
+        } catch (NoSuchPaddingException | InvalidAlgorithmParameterException ex) {
             throw new GenericCryptoException(ex.getMessage(), ex);
         }
     }
@@ -70,8 +74,9 @@ public class AESEncryptionUtils {
      * @throws IllegalBlockSizeException In case invalid key size is provided.
      * @throws BadPaddingException In case invalid padding is provided.
      * @throws GenericCryptoException In case encryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] encrypt(byte[] bytes, byte[] iv, SecretKey secret) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException, GenericCryptoException {
+    public byte[] encrypt(byte[] bytes, byte[] iv, SecretKey secret) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException, GenericCryptoException, CryptoProviderException {
         return this.encrypt(bytes, iv, secret, "AES/CBC/PKCS7Padding");
     }
 
@@ -88,13 +93,16 @@ public class AESEncryptionUtils {
      * @throws IllegalBlockSizeException In case invalid key size is provided.
      * @throws BadPaddingException In case invalid padding is provided.
      * @throws GenericCryptoException In case decryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] decrypt(byte[] bytes, byte[] iv, SecretKey secret, String padding) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException, GenericCryptoException {
+    public byte[] decrypt(byte[] bytes, byte[] iv, SecretKey secret, String padding) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException, GenericCryptoException, CryptoProviderException {
         try {
             Cipher cipherForCryptoResponse = Cipher.getInstance(padding, PowerAuthConfiguration.INSTANCE.getKeyConvertor().getProviderName());
             cipherForCryptoResponse.init(Cipher.DECRYPT_MODE, secret, new IvParameterSpec(iv));
             return cipherForCryptoResponse.doFinal(bytes);
-        } catch (NoSuchAlgorithmException | NoSuchProviderException | NoSuchPaddingException | InvalidAlgorithmParameterException ex) {
+        } catch (NoSuchAlgorithmException | NoSuchProviderException ex) {
+            throw new CryptoProviderException(ex.getMessage(), ex);
+        } catch (NoSuchPaddingException | InvalidAlgorithmParameterException ex) {
             throw new GenericCryptoException(ex.getMessage(), ex);
         }
     }
@@ -111,8 +119,9 @@ public class AESEncryptionUtils {
      * @throws IllegalBlockSizeException In case invalid key size is provided.
      * @throws BadPaddingException In case invalid padding is provided.
      * @throws GenericCryptoException In case decryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] decrypt(byte[] bytes, byte[] iv, SecretKey secret) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException, GenericCryptoException {
+    public byte[] decrypt(byte[] bytes, byte[] iv, SecretKey secret) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException, GenericCryptoException, CryptoProviderException {
         return this.decrypt(bytes, iv, secret, "AES/CBC/PKCS7Padding");
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/AESEncryptionUtils.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/AESEncryptionUtils.java
@@ -45,19 +45,17 @@ public class AESEncryptionUtils {
      * @param padding Padding to be used, for example "AES/CBC/PKCS7Padding".
      * @return Encrypted bytes.
      * @throws InvalidKeyException In case an invalid key is provided.
-     * @throws IllegalBlockSizeException In case invalid key size is provided.
-     * @throws BadPaddingException In case invalid padding is provided.
      * @throws GenericCryptoException In case encryption fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] encrypt(byte[] bytes, byte[] iv, SecretKey secret, String padding) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException, GenericCryptoException, CryptoProviderException {
+    public byte[] encrypt(byte[] bytes, byte[] iv, SecretKey secret, String padding) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         try {
             Cipher cipherForCryptoResponse = Cipher.getInstance(padding, PowerAuthConfiguration.INSTANCE.getKeyConvertor().getProviderName());
             cipherForCryptoResponse.init(Cipher.ENCRYPT_MODE, secret, new IvParameterSpec(iv));
             return cipherForCryptoResponse.doFinal(bytes);
         } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException ex) {
             throw new CryptoProviderException(ex.getMessage(), ex);
-        } catch (NoSuchPaddingException ex) {
+        } catch (IllegalBlockSizeException | BadPaddingException | NoSuchPaddingException ex) {
             throw new GenericCryptoException(ex.getMessage(), ex);
         }
     }
@@ -71,12 +69,10 @@ public class AESEncryptionUtils {
      * @param secret Secret signature key.
      * @return Encrypted bytes.
      * @throws InvalidKeyException In case an invalid key is provided.
-     * @throws IllegalBlockSizeException In case invalid key size is provided.
-     * @throws BadPaddingException In case invalid padding is provided.
      * @throws GenericCryptoException In case encryption fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] encrypt(byte[] bytes, byte[] iv, SecretKey secret) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException, GenericCryptoException, CryptoProviderException {
+    public byte[] encrypt(byte[] bytes, byte[] iv, SecretKey secret) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         return this.encrypt(bytes, iv, secret, "AES/CBC/PKCS7Padding");
     }
 
@@ -90,19 +86,17 @@ public class AESEncryptionUtils {
      * @param padding Padding to be used, for example "AES/CBC/PKCS7Padding".
      * @return Original decrypted bytes.
      * @throws InvalidKeyException In case an invalid key is provided.
-     * @throws IllegalBlockSizeException In case invalid key size is provided.
-     * @throws BadPaddingException In case invalid padding is provided.
      * @throws GenericCryptoException In case decryption fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] decrypt(byte[] bytes, byte[] iv, SecretKey secret, String padding) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException, GenericCryptoException, CryptoProviderException {
+    public byte[] decrypt(byte[] bytes, byte[] iv, SecretKey secret, String padding) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         try {
             Cipher cipherForCryptoResponse = Cipher.getInstance(padding, PowerAuthConfiguration.INSTANCE.getKeyConvertor().getProviderName());
             cipherForCryptoResponse.init(Cipher.DECRYPT_MODE, secret, new IvParameterSpec(iv));
             return cipherForCryptoResponse.doFinal(bytes);
         } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException ex) {
             throw new CryptoProviderException(ex.getMessage(), ex);
-        } catch (NoSuchPaddingException ex) {
+        } catch (IllegalBlockSizeException | BadPaddingException | NoSuchPaddingException ex) {
             throw new GenericCryptoException(ex.getMessage(), ex);
         }
     }
@@ -116,12 +110,10 @@ public class AESEncryptionUtils {
      * @param secret Secret signature key.
      * @return Original decrypted bytes.
      * @throws InvalidKeyException In case an invalid key is provided.
-     * @throws IllegalBlockSizeException In case invalid key size is provided.
-     * @throws BadPaddingException In case invalid padding is provided.
      * @throws GenericCryptoException In case decryption fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] decrypt(byte[] bytes, byte[] iv, SecretKey secret) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException, GenericCryptoException, CryptoProviderException {
+    public byte[] decrypt(byte[] bytes, byte[] iv, SecretKey secret) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         return this.decrypt(bytes, iv, secret, "AES/CBC/PKCS7Padding");
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/AESEncryptionUtils.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/AESEncryptionUtils.java
@@ -17,6 +17,7 @@
 package io.getlime.security.powerauth.crypto.lib.util;
 
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 
 import javax.crypto.*;
 import javax.crypto.spec.IvParameterSpec;
@@ -24,8 +25,6 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * A utility class for AES encryption.
@@ -46,17 +45,17 @@ public class AESEncryptionUtils {
      * @return Encrypted bytes.
      * @throws InvalidKeyException In case an invalid key is provided.
      * @throws IllegalBlockSizeException In case invalid key size is provided.
-     * @throws BadPaddingException In case invalid padding is provided. 
+     * @throws BadPaddingException In case invalid padding is provided.
+     * @throws GenericCryptoException In case encryption fails.
      */
-    public byte[] encrypt(byte[] bytes, byte[] iv, SecretKey secret, String padding) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
+    public byte[] encrypt(byte[] bytes, byte[] iv, SecretKey secret, String padding) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException, GenericCryptoException {
         try {
             Cipher cipherForCryptoResponse = Cipher.getInstance(padding, PowerAuthConfiguration.INSTANCE.getKeyConvertor().getProviderName());
             cipherForCryptoResponse.init(Cipher.ENCRYPT_MODE, secret, new IvParameterSpec(iv));
             return cipherForCryptoResponse.doFinal(bytes);
         } catch (NoSuchAlgorithmException | NoSuchProviderException | NoSuchPaddingException | InvalidAlgorithmParameterException ex) {
-            Logger.getLogger(AESEncryptionUtils.class.getName()).log(Level.SEVERE, null, ex);
+            throw new GenericCryptoException(ex.getMessage(), ex);
         }
-        return null;
     }
 
     /**
@@ -70,8 +69,9 @@ public class AESEncryptionUtils {
      * @throws InvalidKeyException In case an invalid key is provided.
      * @throws IllegalBlockSizeException In case invalid key size is provided.
      * @throws BadPaddingException In case invalid padding is provided.
+     * @throws GenericCryptoException In case encryption fails.
      */
-    public byte[] encrypt(byte[] bytes, byte[] iv, SecretKey secret) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
+    public byte[] encrypt(byte[] bytes, byte[] iv, SecretKey secret) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException, GenericCryptoException {
         return this.encrypt(bytes, iv, secret, "AES/CBC/PKCS7Padding");
     }
 
@@ -87,16 +87,16 @@ public class AESEncryptionUtils {
      * @throws InvalidKeyException In case an invalid key is provided.
      * @throws IllegalBlockSizeException In case invalid key size is provided.
      * @throws BadPaddingException In case invalid padding is provided.
+     * @throws GenericCryptoException In case decryption fails.
      */
-    public byte[] decrypt(byte[] bytes, byte[] iv, SecretKey secret, String padding) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
+    public byte[] decrypt(byte[] bytes, byte[] iv, SecretKey secret, String padding) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException, GenericCryptoException {
         try {
             Cipher cipherForCryptoResponse = Cipher.getInstance(padding, PowerAuthConfiguration.INSTANCE.getKeyConvertor().getProviderName());
             cipherForCryptoResponse.init(Cipher.DECRYPT_MODE, secret, new IvParameterSpec(iv));
             return cipherForCryptoResponse.doFinal(bytes);
         } catch (NoSuchAlgorithmException | NoSuchProviderException | NoSuchPaddingException | InvalidAlgorithmParameterException ex) {
-            Logger.getLogger(AESEncryptionUtils.class.getName()).log(Level.SEVERE, null, ex);
+            throw new GenericCryptoException(ex.getMessage(), ex);
         }
-        return null;
     }
 
     /**
@@ -110,8 +110,9 @@ public class AESEncryptionUtils {
      * @throws InvalidKeyException In case an invalid key is provided.
      * @throws IllegalBlockSizeException In case invalid key size is provided.
      * @throws BadPaddingException In case invalid padding is provided.
+     * @throws GenericCryptoException In case decryption fails.
      */
-    public byte[] decrypt(byte[] bytes, byte[] iv, SecretKey secret) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
+    public byte[] decrypt(byte[] bytes, byte[] iv, SecretKey secret) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException, GenericCryptoException {
         return this.decrypt(bytes, iv, secret, "AES/CBC/PKCS7Padding");
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/HMACHashUtilities.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/HMACHashUtilities.java
@@ -18,6 +18,7 @@ package io.getlime.security.powerauth.crypto.lib.util;
 
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
@@ -39,14 +40,17 @@ public class HMACHashUtilities {
      * @param data Data for the HMAC-SHA256 algorithm.
      * @return HMAC-SHA256 of given data using given key.
      * @throws GenericCryptoException In case hash computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] hash(byte[] key, byte[] data) throws GenericCryptoException {
+    public byte[] hash(byte[] key, byte[] data) throws GenericCryptoException, CryptoProviderException {
         try {
             Mac hmacSha256 = Mac.getInstance("HmacSHA256", PowerAuthConfiguration.INSTANCE.getKeyConvertor().getProviderName());
             SecretKey hmacKey = new SecretKeySpec(key, "HmacSHA256");
             hmacSha256.init(hmacKey);
             return hmacSha256.doFinal(data);
-        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidKeyException ex) {
+        } catch (NoSuchAlgorithmException | NoSuchProviderException ex) {
+            throw new CryptoProviderException(ex.getMessage(), ex);
+        } catch (InvalidKeyException ex) {
             throw new GenericCryptoException(ex.getMessage(), ex);
         }
     }
@@ -57,13 +61,16 @@ public class HMACHashUtilities {
      * @param data Data for the HMAC-SHA256 algorithm.
      * @return HMAC-SHA256 of given data using given key.
      * @throws GenericCryptoException In case hash computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] hash(SecretKey hmacKey, byte[] data) throws GenericCryptoException {
+    public byte[] hash(SecretKey hmacKey, byte[] data) throws GenericCryptoException, CryptoProviderException {
         try {
             Mac hmacSha256 = Mac.getInstance("HmacSHA256", PowerAuthConfiguration.INSTANCE.getKeyConvertor().getProviderName());
             hmacSha256.init(hmacKey);
             return hmacSha256.doFinal(data);
-        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidKeyException ex) {
+        } catch (NoSuchAlgorithmException | NoSuchProviderException ex) {
+            throw new CryptoProviderException(ex.getMessage(), ex);
+        } catch (InvalidKeyException ex) {
             throw new GenericCryptoException(ex.getMessage(), ex);
         }
     }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/HMACHashUtilities.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/HMACHashUtilities.java
@@ -17,6 +17,7 @@
 package io.getlime.security.powerauth.crypto.lib.util;
 
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
@@ -24,8 +25,6 @@ import javax.crypto.spec.SecretKeySpec;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Simple utility class for HMAC-SHA256 algorithm
@@ -39,17 +38,17 @@ public class HMACHashUtilities {
      * @param key Key for the HMAC-SHA256 algorithm
      * @param data Data for the HMAC-SHA256 algorithm.
      * @return HMAC-SHA256 of given data using given key.
+     * @throws GenericCryptoException In case hash computation fails.
      */
-    public byte[] hash(byte[] key, byte[] data) {
+    public byte[] hash(byte[] key, byte[] data) throws GenericCryptoException {
         try {
             Mac hmacSha256 = Mac.getInstance("HmacSHA256", PowerAuthConfiguration.INSTANCE.getKeyConvertor().getProviderName());
             SecretKey hmacKey = new SecretKeySpec(key, "HmacSHA256");
             hmacSha256.init(hmacKey);
             return hmacSha256.doFinal(data);
         } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidKeyException ex) {
-            Logger.getLogger(HMACHashUtilities.class.getName()).log(Level.SEVERE, null, ex);
+            throw new GenericCryptoException(ex.getMessage(), ex);
         }
-        return null;
     }
 
     /**
@@ -57,16 +56,16 @@ public class HMACHashUtilities {
      * @param hmacKey Key for the HMAC-SHA256 algorithm
      * @param data Data for the HMAC-SHA256 algorithm.
      * @return HMAC-SHA256 of given data using given key.
+     * @throws GenericCryptoException In case hash computation fails.
      */
-    public byte[] hash(SecretKey hmacKey, byte[] data) {
+    public byte[] hash(SecretKey hmacKey, byte[] data) throws GenericCryptoException {
         try {
             Mac hmacSha256 = Mac.getInstance("HmacSHA256", PowerAuthConfiguration.INSTANCE.getKeyConvertor().getProviderName());
             hmacSha256.init(hmacKey);
             return hmacSha256.doFinal(data);
         } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidKeyException ex) {
-            Logger.getLogger(HMACHashUtilities.class.getName()).log(Level.SEVERE, null, ex);
+            throw new GenericCryptoException(ex.getMessage(), ex);
         }
-        return null;
     }
 
 }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/HMACHashUtilities.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/HMACHashUtilities.java
@@ -60,7 +60,7 @@ public class HMACHashUtilities {
      * @param hmacKey Key for the HMAC-SHA256 algorithm
      * @param data Data for the HMAC-SHA256 algorithm.
      * @return HMAC-SHA256 of given data using given key.
-     * @throws GenericCryptoException In case hash computation fails.
+     * @throws GenericCryptoException  In case hash computation fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
     public byte[] hash(SecretKey hmacKey, byte[] data) throws GenericCryptoException, CryptoProviderException {

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/SignatureUtils.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/SignatureUtils.java
@@ -90,8 +90,9 @@ public class SignatureUtils {
      * @param ctrData Counter byte array / derived key index.
      * @return PowerAuth signature for given data.
      * @throws GenericCryptoException In case signature computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public String computePowerAuthSignature(byte[] data, List<SecretKey> signatureKeys, byte[] ctrData) throws GenericCryptoException {
+    public String computePowerAuthSignature(byte[] data, List<SecretKey> signatureKeys, byte[] ctrData) throws GenericCryptoException, CryptoProviderException {
         // Prepare a hash
         HMACHashUtilities hmac = new HMACHashUtilities();
 
@@ -133,8 +134,9 @@ public class SignatureUtils {
      * @param ctrData Counter data.
      * @return Return "true" if signature matches, "false" otherwise.
      * @throws GenericCryptoException In case signature computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public boolean validatePowerAuthSignature(byte[] data, String signature, List<SecretKey> signatureKeys, byte[] ctrData) throws GenericCryptoException {
+    public boolean validatePowerAuthSignature(byte[] data, String signature, List<SecretKey> signatureKeys, byte[] ctrData) throws GenericCryptoException, CryptoProviderException {
         return signature.equals(computePowerAuthSignature(data, signatureKeys, ctrData));
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/TokenUtils.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/TokenUtils.java
@@ -18,6 +18,7 @@ package io.getlime.security.powerauth.crypto.lib.util;
 
 import com.google.common.primitives.Bytes;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -92,8 +93,9 @@ public class TokenUtils {
      * @param timestamp Token timestamp, Unix timestamp format encoded as bytes (string representation).
      * @param tokenSecret Token secret, 16 random bytes.
      * @return Token digest computed using provided data bytes with given token secret.
+     * @throws GenericCryptoException In case digest computation fails.
      */
-    public byte[] computeTokenDigest(byte[] nonce, byte[] timestamp, byte[] tokenSecret) {
+    public byte[] computeTokenDigest(byte[] nonce, byte[] timestamp, byte[] tokenSecret) throws GenericCryptoException {
         byte[] amp = "&".getBytes(StandardCharsets.UTF_8);
         byte[] data = Bytes.concat(nonce, amp, timestamp);
         return hmac.hash(tokenSecret, data);
@@ -106,8 +108,9 @@ public class TokenUtils {
      * @param tokenSecret Token secret, 16 random bytes.
      * @param tokenDigest Token digest, 32 bytes to be validated.
      * @return Token digest computed using provided data bytes with given token secret.
+     * @throws GenericCryptoException In case digest computation fails.
      */
-    public boolean validateTokenDigest(byte[] nonce, byte[] timestamp, byte[] tokenSecret, byte[] tokenDigest) {
+    public boolean validateTokenDigest(byte[] nonce, byte[] timestamp, byte[] tokenSecret, byte[] tokenDigest) throws GenericCryptoException {
         return Arrays.equals(computeTokenDigest(nonce, timestamp, tokenSecret), tokenDigest);
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/TokenUtils.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/TokenUtils.java
@@ -19,6 +19,7 @@ package io.getlime.security.powerauth.crypto.lib.util;
 import com.google.common.primitives.Bytes;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -94,8 +95,9 @@ public class TokenUtils {
      * @param tokenSecret Token secret, 16 random bytes.
      * @return Token digest computed using provided data bytes with given token secret.
      * @throws GenericCryptoException In case digest computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] computeTokenDigest(byte[] nonce, byte[] timestamp, byte[] tokenSecret) throws GenericCryptoException {
+    public byte[] computeTokenDigest(byte[] nonce, byte[] timestamp, byte[] tokenSecret) throws GenericCryptoException, CryptoProviderException {
         byte[] amp = "&".getBytes(StandardCharsets.UTF_8);
         byte[] data = Bytes.concat(nonce, amp, timestamp);
         return hmac.hash(tokenSecret, data);
@@ -109,8 +111,9 @@ public class TokenUtils {
      * @param tokenDigest Token digest, 32 bytes to be validated.
      * @return Token digest computed using provided data bytes with given token secret.
      * @throws GenericCryptoException In case digest computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public boolean validateTokenDigest(byte[] nonce, byte[] timestamp, byte[] tokenSecret, byte[] tokenDigest) throws GenericCryptoException {
+    public boolean validateTokenDigest(byte[] nonce, byte[] timestamp, byte[] tokenSecret, byte[] tokenDigest) throws GenericCryptoException, CryptoProviderException {
         return Arrays.equals(computeTokenDigest(nonce, timestamp, tokenSecret), tokenDigest);
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/activation/PowerAuthServerActivation.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/activation/PowerAuthServerActivation.java
@@ -127,8 +127,9 @@ public class PowerAuthServerActivation {
      * @param signature Signature to be checked against.
      * @return True if the signature is correct, false otherwise.
      * @throws GenericCryptoException In case signature computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public boolean validateApplicationSignature(String activationIdShort, byte[] activationNonce, byte[] encryptedDevicePublicKey, byte[] applicationKey, byte[] applicationSecret, byte[] signature) throws GenericCryptoException {
+    public boolean validateApplicationSignature(String activationIdShort, byte[] activationNonce, byte[] encryptedDevicePublicKey, byte[] applicationKey, byte[] applicationSecret, byte[] signature) throws GenericCryptoException, CryptoProviderException {
         String signatureBaseString = activationIdShort + "&"
                 + BaseEncoding.base64().encode(activationNonce) + "&"
                 + BaseEncoding.base64().encode(encryptedDevicePublicKey) + "&"
@@ -155,8 +156,9 @@ public class PowerAuthServerActivation {
      * for AES encryption.
      * @return A decrypted public key.
      * @throws GenericCryptoException In case decryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public PublicKey decryptDevicePublicKey(byte[] C_devicePublicKey, String activationIdShort, PrivateKey masterPrivateKey, PublicKey ephemeralPublicKey, String activationOTP, byte[] activationNonce) throws GenericCryptoException {
+    public PublicKey decryptDevicePublicKey(byte[] C_devicePublicKey, String activationIdShort, PrivateKey masterPrivateKey, PublicKey ephemeralPublicKey, String activationOTP, byte[] activationNonce) throws GenericCryptoException, CryptoProviderException {
         try {
             // Derive longer key from short activation ID and activation OTP
             byte[] activationIdShortBytes = activationIdShort.getBytes(StandardCharsets.UTF_8);
@@ -183,7 +185,7 @@ public class PowerAuthServerActivation {
 
             }
 
-        } catch (IllegalBlockSizeException | InvalidKeySpecException | BadPaddingException | InvalidKeyException | CryptoProviderException ex) {
+        } catch (IllegalBlockSizeException | InvalidKeySpecException | BadPaddingException | InvalidKeyException ex) {
             throw new GenericCryptoException(ex.getMessage(), ex);
         }
     }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/activation/PowerAuthServerActivation.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/activation/PowerAuthServerActivation.java
@@ -74,9 +74,9 @@ public class PowerAuthServerActivation {
      * Generate a server related activation key pair.
      *
      * @return A new server key pair.
-     * @throws GenericCryptoException In case cryptography provider is incorrectly initialized.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public KeyPair generateServerKeyPair() throws GenericCryptoException {
+    public KeyPair generateServerKeyPair() throws CryptoProviderException {
         return new KeyGenerator().generateKeyPair();
     }
 
@@ -90,15 +90,12 @@ public class PowerAuthServerActivation {
      * @return Signature of activation data using Master Private Key.
      * @throws InvalidKeyException In case Master Private Key is invalid.
      * @throws GenericCryptoException In case signature computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
     public byte[] generateActivationSignature(String activationCode,
-                                              PrivateKey masterPrivateKey) throws InvalidKeyException, GenericCryptoException {
-        try {
-            byte[] bytes = activationCode.getBytes(StandardCharsets.UTF_8);
-            return signatureUtils.computeECDSASignature(bytes, masterPrivateKey);
-        } catch (SignatureException ex) {
-            throw new GenericCryptoException(ex.getMessage(), ex);
-        }
+                                              PrivateKey masterPrivateKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
+        byte[] bytes = activationCode.getBytes(StandardCharsets.UTF_8);
+        return signatureUtils.computeECDSASignature(bytes, masterPrivateKey);
     }
 
     /**
@@ -212,10 +209,11 @@ public class PowerAuthServerActivation {
      * @return Encrypted server public key.
      * @throws InvalidKeyException In case some of the provided keys is invalid.
      * @throws GenericCryptoException In case encryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
     public byte[] encryptServerPublicKey(PublicKey serverPublicKey, PublicKey devicePublicKey,
                                          PrivateKey ephemeralPrivateKey, String activationOTP, String activationIdShort, byte[] activationNonce)
-            throws InvalidKeyException, GenericCryptoException {
+            throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         try {
 
             // Convert public key to bytes
@@ -250,9 +248,10 @@ public class PowerAuthServerActivation {
      * @return Encrypted status blob
      * @throws InvalidKeyException When invalid key is provided.
      * @throws GenericCryptoException In case encryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
     public byte[] encryptedStatusBlob(byte statusByte, byte currentVersionByte, byte upgradeVersionByte, byte failedAttempts, byte maxFailedAttempts, SecretKey transportKey)
-            throws InvalidKeyException, GenericCryptoException {
+            throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         try {
             byte[] padding = new KeyGenerator().generateRandomBytes(17);
             byte[] zeroIv = new byte[16];
@@ -284,18 +283,15 @@ public class PowerAuthServerActivation {
      * @return Signature of the encrypted server public key.
      * @throws InvalidKeyException If master private key is invalid.
      * @throws GenericCryptoException In case signature computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
     public byte[] computeServerDataSignature(String activationId, byte[] C_serverPublicKey, PrivateKey masterPrivateKey)
-            throws InvalidKeyException, GenericCryptoException {
-        try {
-            byte[] activationIdBytes = activationId.getBytes(StandardCharsets.UTF_8);
-            String activationIdBytesBase64 = BaseEncoding.base64().encode(activationIdBytes);
-            String C_serverPublicKeyBase64 = BaseEncoding.base64().encode(C_serverPublicKey);
-            byte[] result = (activationIdBytesBase64 + "&" + C_serverPublicKeyBase64).getBytes(StandardCharsets.UTF_8);
-            return signatureUtils.computeECDSASignature(result, masterPrivateKey);
-        } catch (SignatureException ex) {
-            throw new GenericCryptoException(ex.getMessage(), ex);
-        }
+            throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
+        byte[] activationIdBytes = activationId.getBytes(StandardCharsets.UTF_8);
+        String activationIdBytesBase64 = BaseEncoding.base64().encode(activationIdBytes);
+        String C_serverPublicKeyBase64 = BaseEncoding.base64().encode(C_serverPublicKey);
+        byte[] result = (activationIdBytesBase64 + "&" + C_serverPublicKeyBase64).getBytes(StandardCharsets.UTF_8);
+        return signatureUtils.computeECDSASignature(result, masterPrivateKey);
     }
 
     /**
@@ -304,13 +300,13 @@ public class PowerAuthServerActivation {
      *
      * @param devicePublicKey Public key for computing fingerprint.
      * @return Fingerprint of the public key.
-     * @throws GenericCryptoException In case cryptography provider is incorrectly initialized.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public String computeDevicePublicKeyFingerprint(PublicKey devicePublicKey) throws GenericCryptoException {
+    public String computeDevicePublicKeyFingerprint(PublicKey devicePublicKey) throws CryptoProviderException {
         try {
             return ECPublicKeyFingerprint.compute(((ECPublicKey)devicePublicKey));
         } catch (NoSuchAlgorithmException ex) {
-            throw new GenericCryptoException(ex.getMessage(), ex);
+            throw new CryptoProviderException(ex.getMessage(), ex);
         }
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/keyfactory/PowerAuthServerKeyFactory.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/keyfactory/PowerAuthServerKeyFactory.java
@@ -20,6 +20,7 @@ import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthDerivedKey;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
@@ -46,8 +47,9 @@ public class PowerAuthServerKeyFactory {
      * @return List with keys constructed from master secret that are needed to get
      * requested signature type.
      * @throws GenericCryptoException In case key derivation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public List<SecretKey> keysForSignatureType(PowerAuthSignatureTypes signatureType, SecretKey masterSecretKey) throws GenericCryptoException {
+    public List<SecretKey> keysForSignatureType(PowerAuthSignatureTypes signatureType, SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
 
         List<SecretKey> signatureKeys = new ArrayList<>();
 
@@ -103,8 +105,9 @@ public class PowerAuthServerKeyFactory {
      * @param masterSecretKey Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_ENCRYPTED_VAULT.
      * @throws GenericCryptoException In case key derivation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateServerEncryptedVaultKey(SecretKey masterSecretKey) throws GenericCryptoException {
+    public SecretKey generateServerEncryptedVaultKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(
                 masterSecretKey,
                 PowerAuthDerivedKey.ENCRYPTED_VAULT.getIndex()
@@ -119,11 +122,11 @@ public class PowerAuthServerKeyFactory {
      * @param devicePublicKey Device public key KEY_DEVICE_PUBLIC.
      * @return Computed symmetric key KEY_MASTER_SECRET.
      * @throws InvalidKeyException In case some provided key is invalid.
-     * @throws GenericCryptoException In case shared key computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
     public SecretKey generateServerMasterSecretKey(
             PrivateKey serverPrivateKey,
-            PublicKey devicePublicKey) throws InvalidKeyException, GenericCryptoException {
+            PublicKey devicePublicKey) throws InvalidKeyException, CryptoProviderException {
         return keyGenerator.computeSharedKey(serverPrivateKey, devicePublicKey);
     }
 
@@ -135,8 +138,9 @@ public class PowerAuthServerKeyFactory {
      * @param masterSecretKey Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_BIOMETRY.
      * @throws GenericCryptoException In case key derivation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateServerSignatureBiometryKey(SecretKey masterSecretKey) throws GenericCryptoException {
+    public SecretKey generateServerSignatureBiometryKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(
                 masterSecretKey,
                 PowerAuthDerivedKey.SIGNATURE_BIOMETRY.getIndex()
@@ -151,8 +155,9 @@ public class PowerAuthServerKeyFactory {
      * @param masterSecretKey Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_KNOWLEDGE.
      * @throws GenericCryptoException In case key derivation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateServerSignatureKnowledgeKey(SecretKey masterSecretKey) throws GenericCryptoException {
+    public SecretKey generateServerSignatureKnowledgeKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(
                 masterSecretKey,
                 PowerAuthDerivedKey.SIGNATURE_KNOWLEDGE.getIndex()
@@ -167,8 +172,9 @@ public class PowerAuthServerKeyFactory {
      * @param masterSecretKey Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_POSSESSION.
      * @throws GenericCryptoException In case key derivation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateServerSignaturePossessionKey(SecretKey masterSecretKey) throws GenericCryptoException {
+    public SecretKey generateServerSignaturePossessionKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(
                 masterSecretKey,
                 PowerAuthDerivedKey.SIGNATURE_POSSESSION.getIndex()
@@ -183,8 +189,9 @@ public class PowerAuthServerKeyFactory {
      * @param masterSecretKey Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_TRANSPORT.
      * @throws GenericCryptoException In case key derivation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateServerTransportKey(SecretKey masterSecretKey) throws GenericCryptoException {
+    public SecretKey generateServerTransportKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(
                 masterSecretKey,
                 PowerAuthDerivedKey.TRANSPORT.getIndex()

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/keyfactory/PowerAuthServerKeyFactory.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/keyfactory/PowerAuthServerKeyFactory.java
@@ -19,6 +19,7 @@ package io.getlime.security.powerauth.crypto.server.keyfactory;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthDerivedKey;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 
 import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
@@ -44,8 +45,9 @@ public class PowerAuthServerKeyFactory {
      * @param masterSecretKey Master Key Secret
      * @return List with keys constructed from master secret that are needed to get
      * requested signature type.
+     * @throws GenericCryptoException In case key derivation fails.
      */
-    public List<SecretKey> keysForSignatureType(PowerAuthSignatureTypes signatureType, SecretKey masterSecretKey) {
+    public List<SecretKey> keysForSignatureType(PowerAuthSignatureTypes signatureType, SecretKey masterSecretKey) throws GenericCryptoException {
 
         List<SecretKey> signatureKeys = new ArrayList<>();
 
@@ -100,8 +102,9 @@ public class PowerAuthServerKeyFactory {
      * @see KeyGenerator#deriveSecretKey(SecretKey, byte[])
      * @param masterSecretKey Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_ENCRYPTED_VAULT.
+     * @throws GenericCryptoException In case key derivation fails.
      */
-    public SecretKey generateServerEncryptedVaultKey(SecretKey masterSecretKey) {
+    public SecretKey generateServerEncryptedVaultKey(SecretKey masterSecretKey) throws GenericCryptoException {
         return keyGenerator.deriveSecretKey(
                 masterSecretKey,
                 PowerAuthDerivedKey.ENCRYPTED_VAULT.getIndex()
@@ -116,10 +119,11 @@ public class PowerAuthServerKeyFactory {
      * @param devicePublicKey Device public key KEY_DEVICE_PUBLIC.
      * @return Computed symmetric key KEY_MASTER_SECRET.
      * @throws InvalidKeyException In case some provided key is invalid.
+     * @throws GenericCryptoException In case shared key computation fails.
      */
     public SecretKey generateServerMasterSecretKey(
             PrivateKey serverPrivateKey,
-            PublicKey devicePublicKey) throws InvalidKeyException {
+            PublicKey devicePublicKey) throws InvalidKeyException, GenericCryptoException {
         return keyGenerator.computeSharedKey(serverPrivateKey, devicePublicKey);
     }
 
@@ -130,8 +134,9 @@ public class PowerAuthServerKeyFactory {
      * @see KeyGenerator#deriveSecretKey(SecretKey, byte[])
      * @param masterSecretKey Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_BIOMETRY.
+     * @throws GenericCryptoException In case key derivation fails.
      */
-    public SecretKey generateServerSignatureBiometryKey(SecretKey masterSecretKey) {
+    public SecretKey generateServerSignatureBiometryKey(SecretKey masterSecretKey) throws GenericCryptoException {
         return keyGenerator.deriveSecretKey(
                 masterSecretKey,
                 PowerAuthDerivedKey.SIGNATURE_BIOMETRY.getIndex()
@@ -145,8 +150,9 @@ public class PowerAuthServerKeyFactory {
      * @see KeyGenerator#deriveSecretKey(SecretKey, byte[])
      * @param masterSecretKey Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_KNOWLEDGE.
+     * @throws GenericCryptoException In case key derivation fails.
      */
-    public SecretKey generateServerSignatureKnowledgeKey(SecretKey masterSecretKey) {
+    public SecretKey generateServerSignatureKnowledgeKey(SecretKey masterSecretKey) throws GenericCryptoException {
         return keyGenerator.deriveSecretKey(
                 masterSecretKey,
                 PowerAuthDerivedKey.SIGNATURE_KNOWLEDGE.getIndex()
@@ -160,8 +166,9 @@ public class PowerAuthServerKeyFactory {
      * @see KeyGenerator#deriveSecretKey(SecretKey, byte[])
      * @param masterSecretKey Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_POSSESSION.
+     * @throws GenericCryptoException In case key derivation fails.
      */
-    public SecretKey generateServerSignaturePossessionKey(SecretKey masterSecretKey) {
+    public SecretKey generateServerSignaturePossessionKey(SecretKey masterSecretKey) throws GenericCryptoException {
         return keyGenerator.deriveSecretKey(
                 masterSecretKey,
                 PowerAuthDerivedKey.SIGNATURE_POSSESSION.getIndex()
@@ -175,8 +182,9 @@ public class PowerAuthServerKeyFactory {
      * @see KeyGenerator#deriveSecretKey(SecretKey, byte[])
      * @param masterSecretKey Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_TRANSPORT.
+     * @throws GenericCryptoException In case key derivation fails.
      */
-    public SecretKey generateServerTransportKey(SecretKey masterSecretKey) {
+    public SecretKey generateServerTransportKey(SecretKey masterSecretKey) throws GenericCryptoException {
         return keyGenerator.deriveSecretKey(
                 masterSecretKey,
                 PowerAuthDerivedKey.TRANSPORT.getIndex()

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/keyfactory/PowerAuthServerKeyFactory.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/keyfactory/PowerAuthServerKeyFactory.java
@@ -46,10 +46,11 @@ public class PowerAuthServerKeyFactory {
      * @param masterSecretKey Master Key Secret
      * @return List with keys constructed from master secret that are needed to get
      * requested signature type.
+     * @throws InvalidKeyException In case master secret key is invalid.
      * @throws GenericCryptoException In case key derivation fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public List<SecretKey> keysForSignatureType(PowerAuthSignatureTypes signatureType, SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
+    public List<SecretKey> keysForSignatureType(PowerAuthSignatureTypes signatureType, SecretKey masterSecretKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
 
         List<SecretKey> signatureKeys = new ArrayList<>();
 
@@ -104,10 +105,11 @@ public class PowerAuthServerKeyFactory {
      * @see KeyGenerator#deriveSecretKey(SecretKey, byte[])
      * @param masterSecretKey Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_ENCRYPTED_VAULT.
+     * @throws InvalidKeyException In case master secret key is invalid.
      * @throws GenericCryptoException In case key derivation fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateServerEncryptedVaultKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
+    public SecretKey generateServerEncryptedVaultKey(SecretKey masterSecretKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(
                 masterSecretKey,
                 PowerAuthDerivedKey.ENCRYPTED_VAULT.getIndex()
@@ -137,10 +139,11 @@ public class PowerAuthServerKeyFactory {
      * @see KeyGenerator#deriveSecretKey(SecretKey, byte[])
      * @param masterSecretKey Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_BIOMETRY.
+     * @throws InvalidKeyException In case master secret key is invalid.
      * @throws GenericCryptoException In case key derivation fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateServerSignatureBiometryKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
+    public SecretKey generateServerSignatureBiometryKey(SecretKey masterSecretKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(
                 masterSecretKey,
                 PowerAuthDerivedKey.SIGNATURE_BIOMETRY.getIndex()
@@ -154,10 +157,11 @@ public class PowerAuthServerKeyFactory {
      * @see KeyGenerator#deriveSecretKey(SecretKey, byte[])
      * @param masterSecretKey Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_KNOWLEDGE.
+     * @throws InvalidKeyException In case master secret key is invalid.
      * @throws GenericCryptoException In case key derivation fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateServerSignatureKnowledgeKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
+    public SecretKey generateServerSignatureKnowledgeKey(SecretKey masterSecretKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(
                 masterSecretKey,
                 PowerAuthDerivedKey.SIGNATURE_KNOWLEDGE.getIndex()
@@ -171,10 +175,11 @@ public class PowerAuthServerKeyFactory {
      * @see KeyGenerator#deriveSecretKey(SecretKey, byte[])
      * @param masterSecretKey Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_SIGNATURE_POSSESSION.
+     * @throws InvalidKeyException In case master secret key is invalid.
      * @throws GenericCryptoException In case key derivation fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateServerSignaturePossessionKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
+    public SecretKey generateServerSignaturePossessionKey(SecretKey masterSecretKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(
                 masterSecretKey,
                 PowerAuthDerivedKey.SIGNATURE_POSSESSION.getIndex()
@@ -188,10 +193,11 @@ public class PowerAuthServerKeyFactory {
      * @see KeyGenerator#deriveSecretKey(SecretKey, byte[])
      * @param masterSecretKey Master secret key KEY_MASTER_SECRET.
      * @return An instance of signature key KEY_TRANSPORT.
+     * @throws InvalidKeyException In case master secret key is invalid.
      * @throws GenericCryptoException In case key derivation fails.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public SecretKey generateServerTransportKey(SecretKey masterSecretKey) throws GenericCryptoException, CryptoProviderException {
+    public SecretKey generateServerTransportKey(SecretKey masterSecretKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         return keyGenerator.deriveSecretKey(
                 masterSecretKey,
                 PowerAuthDerivedKey.TRANSPORT.getIndex()

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/signature/PowerAuthServerSignature.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/signature/PowerAuthServerSignature.java
@@ -18,6 +18,7 @@ package io.getlime.security.powerauth.crypto.server.signature;
 
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.SignatureUtils;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 import javax.crypto.SecretKey;
 import java.util.List;
@@ -43,8 +44,9 @@ public class PowerAuthServerSignature {
      * @param ctrData Hash based counter / derived signing key index.
      * @return Returns "true" if the signature matches, "false" otherwise.
      * @throws GenericCryptoException In case signature computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public boolean verifySignatureForData(byte[] data, String signature, List<SecretKey> signatureKeys, byte[] ctrData) throws GenericCryptoException {
+    public boolean verifySignatureForData(byte[] data, String signature, List<SecretKey> signatureKeys, byte[] ctrData) throws GenericCryptoException, CryptoProviderException {
         return signatureUtils.validatePowerAuthSignature(data, signature, signatureKeys, ctrData);
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/signature/PowerAuthServerSignature.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/signature/PowerAuthServerSignature.java
@@ -16,6 +16,7 @@
  */
 package io.getlime.security.powerauth.crypto.server.signature;
 
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.SignatureUtils;
 
 import javax.crypto.SecretKey;
@@ -41,8 +42,9 @@ public class PowerAuthServerSignature {
      * @param signatureKeys Keys used for signature.
      * @param ctrData Hash based counter / derived signing key index.
      * @return Returns "true" if the signature matches, "false" otherwise.
+     * @throws GenericCryptoException In case signature computation fails.
      */
-    public boolean verifySignatureForData(byte[] data, String signature, List<SecretKey> signatureKeys, byte[] ctrData) {
+    public boolean verifySignatureForData(byte[] data, String signature, List<SecretKey> signatureKeys, byte[] ctrData) throws GenericCryptoException {
         return signatureUtils.validatePowerAuthSignature(data, signature, signatureKeys, ctrData);
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/token/ServerTokenVerifier.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/token/ServerTokenVerifier.java
@@ -16,6 +16,7 @@
  */
 package io.getlime.security.powerauth.crypto.server.token;
 
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.TokenUtils;
 
 /**
@@ -45,8 +46,9 @@ public class ServerTokenVerifier {
      * @param tokenSecret Token secret, 16 random bytes.
      * @param tokenDigest Token digest, 32 bytes to be validated.
      * @return Token digest computed using provided data bytes with given token secret.
+     * @throws GenericCryptoException In case digest computation fails.
      */
-    public boolean validateTokenDigest(byte[] nonce, byte[] timestamp, byte[] tokenSecret, byte[] tokenDigest) {
+    public boolean validateTokenDigest(byte[] nonce, byte[] timestamp, byte[] tokenSecret, byte[] tokenDigest) throws GenericCryptoException {
         return tokenUtils.validateTokenDigest(nonce, timestamp, tokenSecret, tokenDigest);
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/token/ServerTokenVerifier.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/token/ServerTokenVerifier.java
@@ -18,6 +18,7 @@ package io.getlime.security.powerauth.crypto.server.token;
 
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.TokenUtils;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 /**
  * Class to simplify token verification on the server side.
@@ -47,8 +48,9 @@ public class ServerTokenVerifier {
      * @param tokenDigest Token digest, 32 bytes to be validated.
      * @return Token digest computed using provided data bytes with given token secret.
      * @throws GenericCryptoException In case digest computation fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public boolean validateTokenDigest(byte[] nonce, byte[] timestamp, byte[] tokenSecret, byte[] tokenDigest) throws GenericCryptoException {
+    public boolean validateTokenDigest(byte[] nonce, byte[] timestamp, byte[] tokenSecret, byte[] tokenDigest) throws GenericCryptoException, CryptoProviderException {
         return tokenUtils.validateTokenDigest(nonce, timestamp, tokenSecret, tokenDigest);
     }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/util/DataDigest.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/util/DataDigest.java
@@ -19,6 +19,7 @@ package io.getlime.security.powerauth.crypto.server.util;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.HMACHashUtilities;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -80,7 +81,7 @@ public class DataDigest {
             String digitFormat = "%" + String.format("%02d", AUTHORIZATION_CODE_LENGTH) + "d";
             String digest = String.format(digitFormat, otp);
             return new Result(digest, randomKey);
-        } catch (GenericCryptoException ex) {
+        } catch (GenericCryptoException | CryptoProviderException ex) {
             return null;
         }
     }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/vault/PowerAuthServerVault.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/vault/PowerAuthServerVault.java
@@ -24,8 +24,6 @@ import io.getlime.security.powerauth.crypto.lib.util.AESEncryptionUtils;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
-import javax.crypto.BadPaddingException;
-import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
 import java.security.PrivateKey;
@@ -58,21 +56,17 @@ public class PowerAuthServerVault {
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
     public byte[] encryptVaultEncryptionKey(PrivateKey serverPrivateKey, PublicKey devicePublicKey, byte[] ctr) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
-        try {
-            KeyGenerator keyGenerator = new KeyGenerator();
-            SecretKey keyMasterSecret = keyGenerator.computeSharedKey(serverPrivateKey, devicePublicKey);
-            SecretKey keyMasterTransport = keyGenerator.deriveSecretKey(keyMasterSecret, PowerAuthDerivedKey.TRANSPORT.getIndex());
-            SecretKey keyVaultEncryptionTransport = keyGenerator.deriveSecretKey(keyMasterTransport, ctr);
-            SecretKey keyVaultEncryption = keyGenerator.deriveSecretKey(keyMasterSecret, PowerAuthDerivedKey.ENCRYPTED_VAULT.getIndex());
+        KeyGenerator keyGenerator = new KeyGenerator();
+        SecretKey keyMasterSecret = keyGenerator.computeSharedKey(serverPrivateKey, devicePublicKey);
+        SecretKey keyMasterTransport = keyGenerator.deriveSecretKey(keyMasterSecret, PowerAuthDerivedKey.TRANSPORT.getIndex());
+        SecretKey keyVaultEncryptionTransport = keyGenerator.deriveSecretKey(keyMasterTransport, ctr);
+        SecretKey keyVaultEncryption = keyGenerator.deriveSecretKey(keyMasterSecret, PowerAuthDerivedKey.ENCRYPTED_VAULT.getIndex());
 
-            CryptoProviderUtil keyConvertor = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
-            byte[] keyVaultEncryptionBytes = keyConvertor.convertSharedSecretKeyToBytes(keyVaultEncryption);
-            byte[] iv = new byte[16];
-            AESEncryptionUtils aes = new AESEncryptionUtils();
-            return aes.encrypt(keyVaultEncryptionBytes, iv, keyVaultEncryptionTransport);
-        } catch (IllegalBlockSizeException | BadPaddingException ex) {
-            throw new GenericCryptoException(ex.getMessage(), ex);
-        }
+        CryptoProviderUtil keyConvertor = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
+        byte[] keyVaultEncryptionBytes = keyConvertor.convertSharedSecretKeyToBytes(keyVaultEncryption);
+        byte[] iv = new byte[16];
+        AESEncryptionUtils aes = new AESEncryptionUtils();
+        return aes.encrypt(keyVaultEncryptionBytes, iv, keyVaultEncryptionTransport);
     }
 
     /**
@@ -91,20 +85,16 @@ public class PowerAuthServerVault {
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
     public byte[] encryptVaultEncryptionKey(PrivateKey serverPrivateKey, PublicKey devicePublicKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
-        try {
-            KeyGenerator keyGenerator = new KeyGenerator();
-            SecretKey keyMasterSecret = keyGenerator.computeSharedKey(serverPrivateKey, devicePublicKey);
-            SecretKey keyTransport = keyGenerator.deriveSecretKey(keyMasterSecret, PowerAuthDerivedKey.TRANSPORT.getIndex());
-            SecretKey keyVaultEncryption = keyGenerator.deriveSecretKey(keyMasterSecret, PowerAuthDerivedKey.ENCRYPTED_VAULT.getIndex());
+        KeyGenerator keyGenerator = new KeyGenerator();
+        SecretKey keyMasterSecret = keyGenerator.computeSharedKey(serverPrivateKey, devicePublicKey);
+        SecretKey keyTransport = keyGenerator.deriveSecretKey(keyMasterSecret, PowerAuthDerivedKey.TRANSPORT.getIndex());
+        SecretKey keyVaultEncryption = keyGenerator.deriveSecretKey(keyMasterSecret, PowerAuthDerivedKey.ENCRYPTED_VAULT.getIndex());
 
-            CryptoProviderUtil keyConvertor = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
-            byte[] keyVaultEncryptionBytes = keyConvertor.convertSharedSecretKeyToBytes(keyVaultEncryption);
-            byte[] iv = new byte[16];
-            AESEncryptionUtils aes = new AESEncryptionUtils();
-            return aes.encrypt(keyVaultEncryptionBytes, iv, keyTransport);
-        } catch (IllegalBlockSizeException | BadPaddingException ex) {
-            throw new GenericCryptoException(ex.getMessage(), ex);
-        }
+        CryptoProviderUtil keyConvertor = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
+        byte[] keyVaultEncryptionBytes = keyConvertor.convertSharedSecretKeyToBytes(keyVaultEncryption);
+        byte[] iv = new byte[16];
+        AESEncryptionUtils aes = new AESEncryptionUtils();
+        return aes.encrypt(keyVaultEncryptionBytes, iv, keyTransport);
     }
 
 }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/vault/PowerAuthServerVault.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/vault/PowerAuthServerVault.java
@@ -22,6 +22,7 @@ import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
 import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.AESEncryptionUtils;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
@@ -54,8 +55,9 @@ public class PowerAuthServerVault {
      * @return Encrypted vault encryption key.
      * @throws InvalidKeyException In case a provided key is incorrect.
      * @throws GenericCryptoException In case encryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] encryptVaultEncryptionKey(PrivateKey serverPrivateKey, PublicKey devicePublicKey, byte[] ctr) throws InvalidKeyException, GenericCryptoException {
+    public byte[] encryptVaultEncryptionKey(PrivateKey serverPrivateKey, PublicKey devicePublicKey, byte[] ctr) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         try {
             KeyGenerator keyGenerator = new KeyGenerator();
             SecretKey keyMasterSecret = keyGenerator.computeSharedKey(serverPrivateKey, devicePublicKey);
@@ -86,8 +88,9 @@ public class PowerAuthServerVault {
      * @return Encrypted vault encryption key.
      * @throws InvalidKeyException In case a provided key is incorrect.
      * @throws GenericCryptoException In case encryption fails.
+     * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
-    public byte[] encryptVaultEncryptionKey(PrivateKey serverPrivateKey, PublicKey devicePublicKey) throws InvalidKeyException, GenericCryptoException {
+    public byte[] encryptVaultEncryptionKey(PrivateKey serverPrivateKey, PublicKey devicePublicKey) throws InvalidKeyException, GenericCryptoException, CryptoProviderException {
         try {
             KeyGenerator keyGenerator = new KeyGenerator();
             SecretKey keyMasterSecret = keyGenerator.computeSharedKey(serverPrivateKey, devicePublicKey);

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/vault/PowerAuthServerVault.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/vault/PowerAuthServerVault.java
@@ -19,6 +19,7 @@ package io.getlime.security.powerauth.crypto.server.vault;
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthDerivedKey;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.AESEncryptionUtils;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 
@@ -28,8 +29,6 @@ import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Class implementing server-side logic for PowerAuth vault encryption.
@@ -54,8 +53,9 @@ public class PowerAuthServerVault {
      * @param ctr Counter data.
      * @return Encrypted vault encryption key.
      * @throws InvalidKeyException In case a provided key is incorrect.
+     * @throws GenericCryptoException In case encryption fails.
      */
-    public byte[] encryptVaultEncryptionKey(PrivateKey serverPrivateKey, PublicKey devicePublicKey, byte[] ctr) throws InvalidKeyException {
+    public byte[] encryptVaultEncryptionKey(PrivateKey serverPrivateKey, PublicKey devicePublicKey, byte[] ctr) throws InvalidKeyException, GenericCryptoException {
         try {
             KeyGenerator keyGenerator = new KeyGenerator();
             SecretKey keyMasterSecret = keyGenerator.computeSharedKey(serverPrivateKey, devicePublicKey);
@@ -69,9 +69,8 @@ public class PowerAuthServerVault {
             AESEncryptionUtils aes = new AESEncryptionUtils();
             return aes.encrypt(keyVaultEncryptionBytes, iv, keyVaultEncryptionTransport);
         } catch (IllegalBlockSizeException | BadPaddingException ex) {
-            Logger.getLogger(PowerAuthServerVault.class.getName()).log(Level.SEVERE, null, ex);
+            throw new GenericCryptoException(ex.getMessage(), ex);
         }
-        return null;
     }
 
     /**
@@ -86,8 +85,9 @@ public class PowerAuthServerVault {
      * @param devicePublicKey Device public key KEY_DEVICE_PUBLIC
      * @return Encrypted vault encryption key.
      * @throws InvalidKeyException In case a provided key is incorrect.
+     * @throws GenericCryptoException In case encryption fails.
      */
-    public byte[] encryptVaultEncryptionKey(PrivateKey serverPrivateKey, PublicKey devicePublicKey) throws InvalidKeyException {
+    public byte[] encryptVaultEncryptionKey(PrivateKey serverPrivateKey, PublicKey devicePublicKey) throws InvalidKeyException, GenericCryptoException {
         try {
             KeyGenerator keyGenerator = new KeyGenerator();
             SecretKey keyMasterSecret = keyGenerator.computeSharedKey(serverPrivateKey, devicePublicKey);
@@ -100,9 +100,8 @@ public class PowerAuthServerVault {
             AESEncryptionUtils aes = new AESEncryptionUtils();
             return aes.encrypt(keyVaultEncryptionBytes, iv, keyTransport);
         } catch (IllegalBlockSizeException | BadPaddingException ex) {
-            Logger.getLogger(PowerAuthServerVault.class.getName()).log(Level.SEVERE, null, ex);
+            throw new GenericCryptoException(ex.getMessage(), ex);
         }
-        return null;
     }
 
 }

--- a/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/activation/ActivationStatusBlobInfoTest.java
+++ b/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/activation/ActivationStatusBlobInfoTest.java
@@ -20,6 +20,7 @@ import io.getlime.security.powerauth.crypto.client.activation.PowerAuthClientAct
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
 import io.getlime.security.powerauth.crypto.lib.model.ActivationStatusBlobInfo;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.AESEncryptionUtils;
 import io.getlime.security.powerauth.crypto.server.activation.PowerAuthServerActivation;
 import io.getlime.security.powerauth.crypto.server.keyfactory.PowerAuthServerKeyFactory;
@@ -57,7 +58,7 @@ public class ActivationStatusBlobInfoTest {
     }
 
     @Test
-    public void testActivationStatusBlob() throws  InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
+    public void testActivationStatusBlob() throws InvalidKeyException, BadPaddingException, IllegalBlockSizeException, GenericCryptoException {
         final PowerAuthServerActivation serverActivation = new PowerAuthServerActivation();
         final PowerAuthClientActivation clientActivation = new PowerAuthClientActivation();
         // Simulate generating of device and server key pairs

--- a/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/activation/ActivationStatusBlobInfoTest.java
+++ b/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/activation/ActivationStatusBlobInfoTest.java
@@ -25,6 +25,7 @@ import io.getlime.security.powerauth.crypto.lib.util.AESEncryptionUtils;
 import io.getlime.security.powerauth.crypto.server.activation.PowerAuthServerActivation;
 import io.getlime.security.powerauth.crypto.server.keyfactory.PowerAuthServerKeyFactory;
 import io.getlime.security.powerauth.provider.CryptoProviderUtilFactory;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,7 +59,7 @@ public class ActivationStatusBlobInfoTest {
     }
 
     @Test
-    public void testActivationStatusBlob() throws InvalidKeyException, BadPaddingException, IllegalBlockSizeException, GenericCryptoException {
+    public void testActivationStatusBlob() throws InvalidKeyException, BadPaddingException, IllegalBlockSizeException, GenericCryptoException, CryptoProviderException {
         final PowerAuthServerActivation serverActivation = new PowerAuthServerActivation();
         final PowerAuthClientActivation clientActivation = new PowerAuthClientActivation();
         // Simulate generating of device and server key pairs

--- a/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/activation/PowerAuthActivationTest.java
+++ b/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/activation/PowerAuthActivationTest.java
@@ -20,10 +20,10 @@ import com.google.common.io.BaseEncoding;
 import io.getlime.security.powerauth.crypto.client.activation.PowerAuthClientActivation;
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
-import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.server.activation.PowerAuthServerActivation;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.provider.CryptoProviderUtilFactory;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +56,7 @@ public class PowerAuthActivationTest {
 	 * Test that the keys are correctly generated.
 	 */
 	@Test
-	public void testGenerateKeys() throws GenericCryptoException {
+	public void testGenerateKeys() throws CryptoProviderException {
 		CryptoProviderUtil keyConvertor = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
 		KeyGenerator keyGenerator = new KeyGenerator();
 		KeyPair kp = keyGenerator.generateKeyPair();

--- a/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/activation/PowerAuthActivationTest.java
+++ b/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/activation/PowerAuthActivationTest.java
@@ -20,6 +20,7 @@ import com.google.common.io.BaseEncoding;
 import io.getlime.security.powerauth.crypto.client.activation.PowerAuthClientActivation;
 import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.server.activation.PowerAuthServerActivation;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.provider.CryptoProviderUtilFactory;
@@ -55,7 +56,7 @@ public class PowerAuthActivationTest {
 	 * Test that the keys are correctly generated.
 	 */
 	@Test
-	public void testGenerateKeys() {
+	public void testGenerateKeys() throws GenericCryptoException {
 		CryptoProviderUtil keyConvertor = PowerAuthConfiguration.INSTANCE.getKeyConvertor();
 		KeyGenerator keyGenerator = new KeyGenerator();
 		KeyPair kp = keyGenerator.generateKeyPair();

--- a/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/encryption/EciesEncryptorTest.java
+++ b/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/encryption/EciesEncryptorTest.java
@@ -25,6 +25,7 @@ import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.exception.EciesE
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.kdf.KdfX9_63;
 import io.getlime.security.powerauth.crypto.lib.encryptor.ecies.model.EciesCryptogram;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import io.getlime.security.powerauth.crypto.lib.util.Hash;
 import io.getlime.security.powerauth.provider.CryptoProviderUtil;
 import io.getlime.security.powerauth.provider.CryptoProviderUtilFactory;
@@ -189,7 +190,7 @@ public class EciesEncryptorTest {
      * Test KDF implementation (X9.63 with SHA 256).
      */
     @Test
-    public void testKdf() {
+    public void testKdf() throws GenericCryptoException {
 
         for (int i = 0 ; i < 100 ; i++) {
             final SecretKey secretKey = keyGenerator.generateRandomSecretKey();

--- a/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtil.java
+++ b/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtil.java
@@ -16,6 +16,8 @@
  */
 package io.getlime.security.powerauth.provider;
 
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
+
 import javax.crypto.SecretKey;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -52,8 +54,9 @@ public interface CryptoProviderUtil {
      * @return An instance of the EC public key on success, or null on failure.
      * @throws InvalidKeySpecException When provided bytes are not a correct key
      *                                 representation.
+     * @throws CryptoProviderException When crypto provider is incorrectly initialized.
      */
-    PublicKey convertBytesToPublicKey(byte[] keyBytes) throws InvalidKeySpecException;
+    PublicKey convertBytesToPublicKey(byte[] keyBytes) throws InvalidKeySpecException, CryptoProviderException;
 
     /**
      * Converts an EC private key to bytes by encoding the D number parameter.
@@ -71,8 +74,9 @@ public interface CryptoProviderUtil {
      * @return An instance of EC private key decoded from the input bytes.
      * @throws InvalidKeySpecException The provided key bytes are not a valid EC
      *                                 private key.
+     * @throws CryptoProviderException When crypto provider is incorrectly initialized.
      */
-    PrivateKey convertBytesToPrivateKey(byte[] keyBytes) throws InvalidKeySpecException;
+    PrivateKey convertBytesToPrivateKey(byte[] keyBytes) throws InvalidKeySpecException, CryptoProviderException;
 
     /**
      * Converts a shared secret key (usually used for AES based operations) to a

--- a/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtilBouncyCastle.java
+++ b/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtilBouncyCastle.java
@@ -16,6 +16,7 @@
  */
 package io.getlime.security.powerauth.provider;
 
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 import org.bouncycastle.jce.ECNamedCurveTable;
 import org.bouncycastle.jce.interfaces.ECPrivateKey;
 import org.bouncycastle.jce.interfaces.ECPublicKey;
@@ -30,8 +31,6 @@ import javax.crypto.spec.SecretKeySpec;
 import java.math.BigInteger;
 import java.security.*;
 import java.security.spec.InvalidKeySpecException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Crypto provider based on BouncyCastle crypto provider.
@@ -68,8 +67,9 @@ public class CryptoProviderUtilBouncyCastle implements CryptoProviderUtil {
      * @return An instance of the EC public key on success, or null on failure.
      * @throws InvalidKeySpecException When provided bytes are not a correct key
      *                                 representation.
+     * @throws CryptoProviderException When crypto provider is incorrectly initialized.
      */
-    public PublicKey convertBytesToPublicKey(byte[] keyBytes) throws InvalidKeySpecException {
+    public PublicKey convertBytesToPublicKey(byte[] keyBytes) throws InvalidKeySpecException, CryptoProviderException {
         try {
             KeyFactory kf = KeyFactory.getInstance("ECDH", getProviderName());
 
@@ -82,9 +82,8 @@ public class CryptoProviderUtilBouncyCastle implements CryptoProviderUtil {
 
             return kf.generatePublic(pubSpec);
         } catch (NoSuchAlgorithmException | NoSuchProviderException ex) {
-            Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, null, ex);
+            throw new CryptoProviderException(ex.getMessage(), ex);
         }
-        return null;
     }
 
     /**
@@ -105,8 +104,9 @@ public class CryptoProviderUtilBouncyCastle implements CryptoProviderUtil {
      * @return An instance of EC private key decoded from the input bytes.
      * @throws InvalidKeySpecException The provided key bytes are not a valid EC
      *                                 private key.
+     * @throws CryptoProviderException When crypto provider is incorrectly initialized.
      */
-    public PrivateKey convertBytesToPrivateKey(byte[] keyBytes) throws InvalidKeySpecException {
+    public PrivateKey convertBytesToPrivateKey(byte[] keyBytes) throws InvalidKeySpecException, CryptoProviderException {
         try {
             KeyFactory kf = KeyFactory.getInstance("ECDH", getProviderName());
             BigInteger keyInteger = new BigInteger(keyBytes);
@@ -115,9 +115,8 @@ public class CryptoProviderUtilBouncyCastle implements CryptoProviderUtil {
 
             return kf.generatePrivate(pubSpec);
         } catch (NoSuchAlgorithmException | NoSuchProviderException ex) {
-            Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, null, ex);
+            throw new CryptoProviderException(ex.getMessage(), ex);
         }
-        return null;
     }
 
     /**

--- a/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtilBouncyCastle.java
+++ b/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtilBouncyCastle.java
@@ -75,7 +75,7 @@ public class CryptoProviderUtilBouncyCastle implements CryptoProviderUtil {
 
             ECNamedCurveParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec("secp256r1");
             if (ecSpec == null) { // can happen with incorrectly initialized crypto provider.
-                return null;
+                throw new CryptoProviderException("Crypto provider does not support the secp256r1 curve");
             }
             ECPoint point = ecSpec.getCurve().decodePoint(keyBytes);
             ECPublicKeySpec pubSpec = new ECPublicKeySpec(point, ecSpec);

--- a/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtilsSpongyCastle.java
+++ b/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtilsSpongyCastle.java
@@ -16,6 +16,7 @@
  */
 package io.getlime.security.powerauth.provider;
 
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
 import org.spongycastle.jce.ECNamedCurveTable;
 import org.spongycastle.jce.interfaces.ECPrivateKey;
 import org.spongycastle.jce.interfaces.ECPublicKey;
@@ -30,8 +31,6 @@ import javax.crypto.spec.SecretKeySpec;
 import java.math.BigInteger;
 import java.security.*;
 import java.security.spec.InvalidKeySpecException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Crypto provider based on SpongyCastle crypto provider.
@@ -69,9 +68,10 @@ public class CryptoProviderUtilsSpongyCastle implements CryptoProviderUtil {
      * @return An instance of the EC public key on success, or null on failure.
      * @throws InvalidKeySpecException When provided bytes are not a correct key
      *                                 representation.
+     * @throws CryptoProviderException When crypto provider is incorrectly initialized.
      */
     @Override
-    public PublicKey convertBytesToPublicKey(byte[] keyBytes) throws InvalidKeySpecException {
+    public PublicKey convertBytesToPublicKey(byte[] keyBytes) throws InvalidKeySpecException, CryptoProviderException {
         try {
             KeyFactory kf = KeyFactory.getInstance("ECDH", getProviderName());
 
@@ -84,9 +84,8 @@ public class CryptoProviderUtilsSpongyCastle implements CryptoProviderUtil {
 
             return kf.generatePublic(pubSpec);
         } catch (NoSuchAlgorithmException | NoSuchProviderException ex) {
-            Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, null, ex);
+            throw new CryptoProviderException(ex.getMessage(), ex);
         }
-        return null;
     }
 
     /**
@@ -108,9 +107,10 @@ public class CryptoProviderUtilsSpongyCastle implements CryptoProviderUtil {
      * @return An instance of EC private key decoded from the input bytes.
      * @throws InvalidKeySpecException The provided key bytes are not a valid EC
      *                                 private key.
+     * @throws CryptoProviderException When crypto provider is incorrectly initialized.
      */
     @Override
-    public PrivateKey convertBytesToPrivateKey(byte[] keyBytes) throws InvalidKeySpecException {
+    public PrivateKey convertBytesToPrivateKey(byte[] keyBytes) throws InvalidKeySpecException, CryptoProviderException {
         try {
             KeyFactory kf = KeyFactory.getInstance("ECDH", getProviderName());
             BigInteger keyInteger = new BigInteger(keyBytes);
@@ -118,9 +118,8 @@ public class CryptoProviderUtilsSpongyCastle implements CryptoProviderUtil {
             ECPrivateKeySpec pubSpec = new ECPrivateKeySpec(keyInteger, ecSpec);
             return kf.generatePrivate(pubSpec);
         } catch (NoSuchAlgorithmException | NoSuchProviderException ex) {
-            Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, null, ex);
+            throw new CryptoProviderException(ex.getMessage(), ex);
         }
-        return null;
     }
 
     /**

--- a/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtilsSpongyCastle.java
+++ b/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtilsSpongyCastle.java
@@ -77,7 +77,7 @@ public class CryptoProviderUtilsSpongyCastle implements CryptoProviderUtil {
 
             ECNamedCurveParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec("secp256r1");
             if (ecSpec == null) { // can happen with incorrectly initialized crypto provider
-                return null;
+                throw new CryptoProviderException("Crypto provider does not support the secp256r1 curve");
             }
             ECPoint point = ecSpec.getCurve().decodePoint(keyBytes);
             ECPublicKeySpec pubSpec = new ECPublicKeySpec(point, ecSpec);

--- a/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/exception/CryptoProviderException.java
+++ b/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/exception/CryptoProviderException.java
@@ -17,7 +17,7 @@
 package io.getlime.security.powerauth.provider.exception;
 
 /**
- * Exception used for handling case when cryptography provider is not configured.
+ * Exception used for handling case when cryptography provider is incorrectly initialized.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */

--- a/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/exception/CryptoProviderException.java
+++ b/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/exception/CryptoProviderException.java
@@ -1,0 +1,57 @@
+/*
+ * PowerAuth Crypto Library
+ * Copyright 2018 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.provider.exception;
+
+/**
+ * Exception used for handling case when cryptography provider is not configured.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class CryptoProviderException extends Exception {
+
+    /**
+     * Exception without error message.
+     */
+    public CryptoProviderException() {
+        super();
+    }
+
+    /**
+     * Exception with error message.
+     * @param message Error message.
+     */
+    public CryptoProviderException(String message) {
+        super(message);
+    }
+
+    /**
+     * Exception with error message and cause.
+     * @param message Error message.
+     * @param cause Exception cause.
+     */
+    public CryptoProviderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Exception with cause.
+     * @param cause Exception cause.
+     */
+    public CryptoProviderException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
After several iterations, the exception handling logic is following:
- `CryptoProviderException` is used for crypto configuration related exceptions, such as invalid configuration of the provider, old version of the provider, old Java runtime, etc. In other words anything that can be configured before execution. These errors can be fixed by properly configuring the cryptography provider.
- `GenericCryptoException` is used for execution related exceptions, such as invalid padding, illegal block size, signature exception, etc. These errors are not related to configuration, they are related to data used in cryptography.
- `InvalidKeyException` and `InvalidKeySpecException` are thrown separately, because they contain information about invalid keys.