### PR TITLE
Fix #191: Crypto 3.0: Deprecate legacy end-to-end encryption

### DIFF
--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/encryptor/ClientNonPersonalizedEncryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/encryptor/ClientNonPersonalizedEncryptor.java
@@ -16,6 +16,14 @@ import java.security.PublicKey;
 /**
  * Class that simulates client side encryption steps.
  *
+ * <h5>PowerAuth protocol versions:</h5>
+ * <ul>
+ *     <li>2.0</li>
+ *     <li>2.1</li>
+ * </ul>
+ *
+ * Warning: this class will be removed in the future, use ECIES encryption for PowerAuth protocol version 3.0 or higher.
+ *
  * @author Petr Dvorak, petr@wultra.com
  */
 public class ClientNonPersonalizedEncryptor {

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/NonPersonalizedEncryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/NonPersonalizedEncryptor.java
@@ -33,6 +33,14 @@ import java.util.Arrays;
  * Class responsible for encrypting / decrypting data using non-personalized encryption
  * as documented in PowerAuth 2.0 E2EE documentation.
  *
+ * <h5>PowerAuth protocol versions:</h5>
+ * <ul>
+ *     <li>2.0</li>
+ *     <li>2.1</li>
+ * </ul>
+ *
+ * Warning: this class will be removed in the future, use ECIES encryption for PowerAuth protocol version 3.0 or higher.
+ *
  * @author Petr Dvorak, petr@wultra.com
  */
 public class NonPersonalizedEncryptor {

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/model/EncryptedMessage.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/model/EncryptedMessage.java
@@ -20,6 +20,14 @@ package io.getlime.security.powerauth.crypto.lib.encryptor.model;
  * Class representing a base encrypted message, with attributes that are
  * required for PowerAuth 2.0 E2EE to work.
  *
+ * <h5>PowerAuth protocol versions:</h5>
+ * <ul>
+ *     <li>2.0</li>
+ *     <li>2.1</li>
+ * </ul>
+ *
+ * Warning: this class will be removed in the future, use ECIES encryption for PowerAuth protocol version 3.0 or higher.
+ *
  * @author Petr Dvorak, petr@wultra.com
  */
 public class EncryptedMessage {

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/model/NonPersonalizedEncryptedMessage.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/model/NonPersonalizedEncryptedMessage.java
@@ -3,6 +3,14 @@ package io.getlime.security.powerauth.crypto.lib.encryptor.model;
 /**
  * Class representing a non-personalized E2EE encrypted message.
  *
+ * <h5>PowerAuth protocol versions:</h5>
+ * <ul>
+ *     <li>2.0</li>
+ *     <li>2.1</li>
+ * </ul>
+ *
+ * Warning: this class will be removed in the future, use ECIES encryption for PowerAuth protocol version 3.0 or higher.
+ *
  * @author Petr Dvorak, petr@wultra.com
  */
 public class NonPersonalizedEncryptedMessage extends EncryptedMessage {

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/model/PersonalizedEncryptedMessage.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/model/PersonalizedEncryptedMessage.java
@@ -3,6 +3,14 @@ package io.getlime.security.powerauth.crypto.lib.encryptor.model;
 /**
  * Class representing a personalized E2EE encrypted message.
  *
+ * <h5>PowerAuth protocol versions:</h5>
+ * <ul>
+ *     <li>2.0</li>
+ *     <li>2.1</li>
+ * </ul>
+ *
+ * Warning: this class will be removed in the future, use ECIES encryption for PowerAuth protocol version 3.0 or higher.
+ *
  * @author Petr Dvorak, petr@wultra.com
  */
 public class PersonalizedEncryptedMessage extends EncryptedMessage {


### PR DESCRIPTION
I added warnings to the classes which will be deprecated once crypto version 2 is phased out.