### PR TITLE
Crypto updates for recovery codes and PUKs

### DIFF
--- a/docs/Basic-definitions.md
+++ b/docs/Basic-definitions.md
@@ -22,7 +22,7 @@ Following basic cryptography algorithms and parameters are used in the PowerAuth
   - `byte[] signature = ECDSA.sign(byte[] data, PrivateKey privateKey)` - compute signature of given data and private key.
   - `boolean isValid = ECDSA.verify(byte[] data, byte[] signature, PublicKey publicKey)` - verify the signature for given data using a given public key.
 
-- **ECDH** - An algorithm for elliptic curve with Diffie-Helman key exchange, uses P256r1 curve. We define single operation on ECDH, a symmetric key deduction between parties A and B:
+- **ECDH** - An algorithm for elliptic curve with Diffie-Hellman key exchange, uses P256r1 curve. We define single operation on ECDH, a symmetric key deduction between parties A and B:
   - `SecretKey secretKey = ECDH.phase(PrivateKey privateKeyA, PublicKey publicKeyB)`
 
 - **KDF** - A key derivation function used to derive a symmetric key with specific "index" from a given master key. Uses AES algorithm with zero initialization vector to derive the new key in following way: `index` is converted to bytes, XORed with a 16 byte long zero array (to get 16 byte long array with bytes from the index) and AES encrypted using provided symmetric key `masterKey`.
@@ -55,6 +55,10 @@ These functions are used in the pseudo-codes:
 - Hashing and MAC functions.
   - `byte[] signature = Mac.hmacSha256(SecretKey key, byte[] message)` - Compute HMAC-SHA256 signature for given message using provided symmetric key.
   - `byte[] hash = Hash.sha256(byte[] original)` - Compute SHA256 hash of a given input.
+  
+- Password hashing.
+  - `String hash = PasswordHash.hash(byte[] password)` - Compute Argon2 hash for given password. Hash is stored in Modular Crypt Format.
+  - `boolean matches = PasswordHash.verify(byte[] password, String hash)` - Verify password against Argon2 hash stored in Modular Crypt Format.
 
 - Utility functions.
   - `byte[] zeroBytes = ByteUtils.zeroBytes(int N)` - Generate buffer with N zero bytes.

--- a/docs/End-To-End-Encryption.md
+++ b/docs/End-To-End-Encryption.md
@@ -173,6 +173,7 @@ PowerAuth protocol defines following `SHARED_INFO_1` (also called as `sh1` or `s
 | `/pa/v3/upgrade`                      | activation   | `/pa/upgrade` |
 | `/pa/v3/vault/unlock`                 | activation   | `/pa/vault/unlock` |
 | `/pa/v3/token/create`                 | activation   | `/pa/token/create` |
+| `/pa/v3/recovery/confirm`             | activation   | `/pa/recovery/confirm` |
 
 On top of that, following constants can be used for application-specific purposes:
 

--- a/docs/Standard-RESTful-API.md
+++ b/docs/Standard-RESTful-API.md
@@ -17,6 +17,7 @@ Following endpoints are published in PowerAuth Standard RESTful API (protocol ve
 - [`/pa/v3/signature/validate`](#validate-signature) - Validate a signature (requires authentication).
 - [`/pa/v3/upgrade/start`](#upgrade-start) - Start a protocol upgrade (requires encryption).
 - [`/pa/v3/upgrade/commit`](#upgrade-commit) - Commits a protocol upgrade (requires authentication).
+- [`/pa/v3/recovery/confirm`](#confirm-recovery) - Confirm a recovery code (requires authentication and encryption).
 
 Before you continue, you can also read [End-To-End encryption](./End-To-End-Encryption.md) and [Computing and Validating Signatures](./Computing-and-Validating-Signatures.md) documents, describing encryption and authentication, used in the RESTful API.
 
@@ -100,7 +101,7 @@ JSON request object before ECIES level 1 encryption. The `activationData` field 
 {
     "activationType": "CODE",
     "identityAttributes": {
-        "code": "VVVVV-VVVVV-VVVVV-VTFVA",
+        "code": "VVVVV-VVVVV-VVVVV-VTFVA"
     },
     "activationData": {
         "ephemeralPublicKey": "MSUNfS0VZX3JhbmRvbQNESF9QVUJMSUNfS0VZX3JhbmRvbQNESF9QVUJ==",
@@ -366,6 +367,7 @@ You can provide following reasons for a vault unlocking:
 - `ADD_BIOMETRY` - call was used to enable biometric authentication.
 - `FETCH_ENCRYPTION_KEY` - call was used to fetch a generic data encryption key.
 - `SIGN_WITH_DEVICE_PRIVATE_KEY` - call was used to unlock device private key used for ECDSA signatures.
+- `RECOVERY_CODE` - call was used to unlock recovery code.
 
 Actual JSON request body, after the encryption:
 ```json
@@ -517,4 +519,59 @@ JSON request body (an empty JSON):
 JSON response body (an empty JSON):
 ```json
 {}
+```
+
+
+## Confirm Recovery
+
+Confirm a recovery code created for a recovery postcard. The recovery code is confirmed once user receives a postcard with recovery code and PUKs. 
+
+| Request parameter | Value                       |
+| ----------------- | --------------------------- |
+| Method            | `POST`                      |
+| Resource URI      | `/pa/v3/recovery/confirm`   |
+| Signature uriId   | `/pa/recovery/confirm`      |
+| ECIES             | `activation, sh1="/pa/recovery/confirm"` |
+
+### Request
+
+- Headers
+    - `Content-Type: application/json`
+    - `X-PowerAuth-Authorization: PowerAuth ...`
+
+JSON request before ECIES encryption:
+```json
+{
+    "recoveryCode": "VVVVV-VVVVV-VVVVV-VTFVA"
+}
+```
+
+Actual JSON request body after the encryption:
+```json
+{
+    "ephemeralPublicKey": "BPZvFnVgImV2LLIdxRoGPQvp8m0uG9cIwNhs11mXWT+sBcILDYgDuj0DagbS8yNbTju07PPscc/eE7zjQ/0sPSo=",
+    "encryptedData": "fuDZz3jqtJ40JjKHek/57gt3dL4XyLWVq9CYupEudCOnTvo6yq57oW9VWR1/e+Ih",
+    "mac":"dL9IGDMoOuyqScxWv9R5XpOj8B/wRNKoLEo5eL8GonA="
+}
+```
+
+### Response
+
+- Status Code: `200`
+- Headers:
+    - `Content-Type: application/json`
+    
+JSON response before ECIES decryption:
+```json
+{
+    "mac": "ct78kSghyrL+b7N/bpNNI5GRt595xU5Y2qlGEG+j+1U=",
+    "encryptedData": "7LK7qs+OK0cfQPZlkzl2G8z5/IZx0SHhI/BPYFhhxqE="
+}
+```
+
+JSON response after the decryption:
+```json
+{
+    "alreadyConfirmed" : false
+}
 ```

--- a/powerauth-java-crypto/pom.xml
+++ b/powerauth-java-crypto/pom.xml
@@ -55,12 +55,11 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- Bouncy Castle for tests -->
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk15on</artifactId>
 			<version>1.61</version>
-			<scope>test</scope>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/model/EciesSharedInfo1.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/model/EciesSharedInfo1.java
@@ -29,7 +29,8 @@ public enum EciesSharedInfo1 {
     ACTIVATION_LAYER_2("/pa/activation"),
     UPGRADE("/pa/upgrade"),
     VAULT_UNLOCK("/pa/vault/unlock"),
-    CREATE_TOKEN("/pa/token/create");
+    CREATE_TOKEN("/pa/token/create"),
+    RECOVERY_CODE_CONFIRM("/pa/recovery/confirm");
 
     private byte[] value;
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/model/EciesSharedInfo1.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/model/EciesSharedInfo1.java
@@ -30,7 +30,7 @@ public enum EciesSharedInfo1 {
     UPGRADE("/pa/upgrade"),
     VAULT_UNLOCK("/pa/vault/unlock"),
     CREATE_TOKEN("/pa/token/create"),
-    RECOVERY_CODE_CONFIRM("/pa/recovery/confirm");
+    CONFIRM_RECOVERY_CODE("/pa/recovery/confirm");
 
     private byte[] value;
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/IdentifierGenerator.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/IdentifierGenerator.java
@@ -207,7 +207,7 @@ public class IdentifierGenerator {
         // Generate random nonce
         byte[] nonceBytes = keyGenerator.generateRandomBytes(32);
 
-        // Derive recovery key using KDF 9.63 using nonce as shared info, trim output to 26 bytes
+        // Derive recovery key using KDF X9.63 using nonce as shared info, trim output to 26 bytes
         byte[] derivedKeyBytes = KdfX9_63.derive(secretKeyBytes, nonceBytes, 26);
 
         // Construct recovery code using derived recovery key (first 10 bytes)
@@ -265,7 +265,7 @@ public class IdentifierGenerator {
             throw new GenericCryptoException("Invalid input data");
         }
 
-        // Derive recovery key using KDF 9.63 using nonce as shared info, trim output to 26 bytes
+        // Derive recovery key using KDF X9.63 using nonce as shared info, trim output to 26 bytes
         byte[] derivedKeyBytes = KdfX9_63.derive(secretKeyBytes, nonceBytes, 26);
 
         // Construct recovery code using derived recovery key (first 10 bytes)

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/IdentifierGenerator.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/IdentifierGenerator.java
@@ -176,7 +176,7 @@ public class IdentifierGenerator {
     }
 
     /**
-     * Generate recovery code and PUK for given secret key.
+     * Generate recovery code and PUK.
      * @return Recovery code and PUK.
      * @throws GenericCryptoException In case of any cryptography error.
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/IdentifierGenerator.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/IdentifierGenerator.java
@@ -117,6 +117,7 @@ public class IdentifierGenerator {
      * <li>Split Base32 string into 4 groups, each one contains 5 characters. Use "-" as separator.</li>
      * </ul>
      *
+     * @param randomBytes Random bytes to use when generating the activation code.
      * @return Generated activation code.
      */
     public String generateActivationCode(byte[] randomBytes) throws GenericCryptoException {

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/Argon2Hash.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/Argon2Hash.java
@@ -17,7 +17,6 @@
 package io.getlime.security.powerauth.crypto.lib.model;
 
 import com.google.common.io.BaseEncoding;
-import org.bouncycastle.crypto.params.Argon2Parameters;
 
 import java.util.*;
 
@@ -41,7 +40,7 @@ public class Argon2Hash {
     }
 
     /**
-     * Constructor with all parameters.
+     * Constructor with algorithm name.
      * @param algorithm Algorithm name.
      */
     public Argon2Hash(String algorithm) {
@@ -62,28 +61,16 @@ public class Argon2Hash {
         if (parts.length != 6) {
             return null;
         }
-        Argon2Hash mcf = new Argon2Hash();
+        Argon2Hash hash = new Argon2Hash();
         // First part is empty, mcfRef starts with the '$' character
-        mcf.setAlgorithm(parts[1]);
+        hash.setAlgorithm(parts[1]);
         // Version uses syntax "v=[version]"
-        mcf.setVersion(extractVersion(parts[2]));
+        hash.setVersion(extractVersion(parts[2]));
         // Parameters use syntax "m=[memoryInBytes],t=[iterations],p=[parallelism]"
-        mcf.setParameters(extractParameters(parts[3]));
-        mcf.setSalt(BaseEncoding.base64().decode(parts[4]));
-        mcf.setDigest(BaseEncoding.base64().decode(parts[5]));
-        return mcf;
-    }
-
-    /**
-     * Set Argon2 algorithm parameters.
-     * @param argon2Parameters Argon2 algorithm parameters.
-     */
-    public void setParameters(Argon2Parameters argon2Parameters) {
-        version = argon2Parameters.getVersion();
-        setIterations(argon2Parameters.getIterations());
-        setParallelism(argon2Parameters.getLanes());
-        setMemory(argon2Parameters.getMemory() * 1024);
-        setSalt(argon2Parameters.getSalt());
+        hash.setParameters(extractParameters(parts[3]));
+        hash.setSalt(BaseEncoding.base64().decode(parts[4]));
+        hash.setDigest(BaseEncoding.base64().decode(parts[5]));
+        return hash;
     }
 
     /**
@@ -229,7 +216,7 @@ public class Argon2Hash {
     /**
      * Extract version from version definition String.
      * @param versionDef Version definition String.
-     * @return Vesion.
+     * @return Version.
      */
     private static Integer extractVersion(String versionDef) {
         if (versionDef != null && versionDef.startsWith("v=") && versionDef.length() > 2) {

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/Argon2Hash.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/Argon2Hash.java
@@ -18,6 +18,7 @@ package io.getlime.security.powerauth.crypto.lib.model;
 
 import com.google.common.io.BaseEncoding;
 
+import java.io.IOException;
 import java.util.*;
 
 /**
@@ -49,16 +50,17 @@ public class Argon2Hash {
 
     /**
      * Construct Argon2 parameters from definition in Modular Crypt Format.
-     * @param mcfRef Definition in Modular Crypt Format.
+     * @param input Definition in Modular Crypt Format.
      * @return Argon2 parameters instance.
+     * @throws IOException In case parsing of hash fails.
      */
-    public static Argon2Hash parse(String mcfRef) {
-        if (mcfRef == null) {
-            return null;
+    public static Argon2Hash parse(String input) throws IOException {
+        if (input == null) {
+            throw new IOException("Missing input parameter");
         }
-        String[] parts = mcfRef.split("\\$");
+        String[] parts = input.split("\\$");
         Argon2Hash hash = new Argon2Hash();
-        if (mcfRef.matches("\\$argon2(?:i|d|id)]?\\$m=[0-9]+,t=[0-9]+,p=[0-9]+\\$[A-Za-z0-9+/]+\\$[A-Za-z0-9+/]+")) {
+        if (input.matches("\\$argon2(?:i|d|id)]?\\$m=[0-9]+,t=[0-9]+,p=[0-9]+\\$[A-Za-z0-9+/]+\\$[A-Za-z0-9+/]+")) {
             // Version 16 (hex 10) of MCF syntax for Argon2
             // First part is empty, mcfRef starts with the '$' character
             hash.setAlgorithm(parts[1]);
@@ -69,7 +71,7 @@ public class Argon2Hash {
             hash.setDigest(BaseEncoding.base64().decode(parts[4]));
             return hash;
         }
-        if (mcfRef.matches("\\$argon2(?:i|d|id)?\\$v=[0-9]+\\$m=[0-9]+,t=[0-9]+,p=[0-9]+\\$[A-Za-z0-9+/]+\\$[A-Za-z0-9+/]+")) {
+        if (input.matches("\\$argon2(?:i|d|id)?\\$v=[0-9]+\\$m=[0-9]+,t=[0-9]+,p=[0-9]+\\$[A-Za-z0-9+/]+\\$[A-Za-z0-9+/]+")) {
             // Version 19 (hex 13) of MCF syntax for Argon2
             // First part is empty, mcfRef starts with the '$' character
             hash.setAlgorithm(parts[1]);
@@ -81,7 +83,7 @@ public class Argon2Hash {
             hash.setDigest(BaseEncoding.base64().decode(parts[5]));
             return hash;
         }
-        throw new IllegalArgumentException("Invalid hash syntax");
+        throw new IOException("Invalid Argon2 hash syntax");
     }
 
     /**

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/Argon2Hash.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/Argon2Hash.java
@@ -1,0 +1,317 @@
+/*
+ * PowerAuth Crypto Library
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.crypto.lib.model;
+
+import com.google.common.io.BaseEncoding;
+import org.bouncycastle.crypto.params.Argon2Parameters;
+
+import java.util.*;
+
+/**
+ * Class representing Argon2 hash in Modular Crypt Format.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class Argon2Hash {
+
+    private String algorithm;
+    private Integer version;
+    private Map<String, Integer> parameters = new HashMap<>();
+    private byte[] salt;
+    private byte[] digest;
+
+    /**
+     * Default constructor.
+     */
+    private Argon2Hash() {
+    }
+
+    /**
+     * Constructor with all parameters.
+     * @param algorithm Algorithm name.
+     */
+    public Argon2Hash(String algorithm) {
+        this.algorithm = algorithm;
+    }
+
+    /**
+     * Construct Argon2 parameters from definition in Modular Crypt Format.
+     * @param mcfRef Definition in Modular Crypt Format.
+     * @return Argon2 parameters instance.
+     */
+    public static Argon2Hash parse(String mcfRef) {
+        if (mcfRef == null) {
+            return null;
+        }
+        String[] parts = mcfRef.split("\\$");
+        // Version 10 of MCF syntax for Argon2 with fewer parts is not supported
+        if (parts.length != 6) {
+            return null;
+        }
+        Argon2Hash mcf = new Argon2Hash();
+        // First part is empty, mcfRef starts with the '$' character
+        mcf.setAlgorithm(parts[1]);
+        // Version uses syntax "v=[version]"
+        mcf.setVersion(extractVersion(parts[2]));
+        // Parameters use syntax "m=[memoryInBytes],t=[iterations],p=[parallelism]"
+        mcf.setParameters(extractParameters(parts[3]));
+        mcf.setSalt(BaseEncoding.base64().decode(parts[4]));
+        mcf.setDigest(BaseEncoding.base64().decode(parts[5]));
+        return mcf;
+    }
+
+    /**
+     * Set Argon2 algorithm parameters.
+     * @param argon2Parameters Argon2 algorithm parameters.
+     */
+    public void setParameters(Argon2Parameters argon2Parameters) {
+        version = argon2Parameters.getVersion();
+        setIterations(argon2Parameters.getIterations());
+        setParallelism(argon2Parameters.getLanes());
+        setMemory(argon2Parameters.getMemory() * 1024);
+        setSalt(argon2Parameters.getSalt());
+    }
+
+    /**
+     * Get algorithm name.
+     * @return Algorithm name.
+     */
+    public String getAlgorithm() {
+        return algorithm;
+    }
+
+    /**
+     * Set algorithm name.
+     * @param algorithm Algorithm name.
+     */
+    public void setAlgorithm(String algorithm) {
+        this.algorithm = algorithm;
+    }
+
+    /**
+     * Get algorithm version.
+     * @return Algorithm version.
+     */
+    public Integer getVersion() {
+        return version;
+    }
+
+    /**
+     * Set algorithm version.
+     * @param version Algorithm version.
+     */
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+
+    /**
+     * Get algorithm parameters.
+     * @return Algorithm parameters.
+     */
+    public Map<String, Integer> getParameters() {
+        return parameters;
+    }
+
+    /**
+     * Set algorithm parameters.
+     * @param parameters Algorithm parameters.
+     */
+    public void setParameters(Map<String, Integer> parameters) {
+        this.parameters = parameters;
+    }
+
+    /**
+     * Get iteration count.
+     * @return Iteration count.
+     */
+    public Integer getIterations() {
+        return parameters.get("t");
+    }
+
+    /**
+     * Set iteration count.
+     * @param iterations Iteration count.
+     */
+    public void setIterations(Integer iterations) {
+        parameters.put("t", iterations);
+    }
+
+    /**
+     * Get memory in bytes.
+     * @return Memory in bytes.
+     */
+    public Integer getMemory() {
+        return parameters.get("m");
+    }
+
+    /**
+     * Set memory in bytes.
+     * @param memory Memory in bytes.
+     */
+    public void setMemory(Integer memory) {
+        parameters.put("m", memory);
+    }
+
+    /**
+     * Get parallelism parameter.
+     * @return Parallelism parameter.
+     */
+    public Integer getParallelism() {
+        return parameters.get("p");
+    }
+
+    /**
+     * Set parallelism parameter.
+     * @param parallelism Parallelism parameter.
+     */
+    public void setParallelism(Integer parallelism) {
+        parameters.put("p", parallelism);
+    }
+
+    /**
+     * Get salt bytes.
+     * @return Salt bytes.
+     */
+    public byte[] getSalt() {
+        return salt;
+    }
+
+    /**
+     * Set salt bytes.
+     * @param salt Salt bytes.
+     */
+    public void setSalt(byte[] salt) {
+        this.salt = salt;
+    }
+
+    /**
+     * Get digest bytes.
+     * @return Digest bytes.
+     */
+    public byte[] getDigest() {
+        return digest;
+    }
+
+    /**
+     * Set digest bytes.
+     * @param digest Digest bytes.
+     */
+    public void setDigest(byte[] digest) {
+        this.digest = digest;
+    }
+
+    /**
+     * Compare Argon2 hashes.
+     * @param other Other Argon2 hash.
+     * @return True if hashes are identical.
+     */
+    public boolean hashEquals(Argon2Hash other) {
+        if (digest == null || other.digest == null) {
+            return false;
+        }
+        return Arrays.equals(digest, other.digest);
+    }
+
+    /**
+     * Extract version from version definition String.
+     * @param versionDef Version definition String.
+     * @return Vesion.
+     */
+    private static Integer extractVersion(String versionDef) {
+        if (versionDef != null && versionDef.startsWith("v=") && versionDef.length() > 2) {
+            String versionStr = versionDef.substring(2);
+            if (versionStr.matches("[0-9]+")) {
+                return Integer.parseInt(versionStr);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Extract parameters from parameters definition String.
+     * @param paramDef Parameters definition String.
+     * @return Parameters.
+     */
+    private static Map<String, Integer> extractParameters(String paramDef) {
+        Map<String, Integer> parameters = new HashMap<>();
+        if (paramDef == null || !paramDef.contains(",")) {
+            return parameters;
+        }
+        String[] parts = paramDef.split(",");
+        for (String part: parts) {
+            if (!part.contains("=")) {
+                continue;
+            }
+            String[] keyValue = part.split("=");
+            String key = keyValue[0];
+            if (!keyValue[1].matches("[0-9]+")) {
+                continue;
+            }
+            Integer value = Integer.parseInt(keyValue[1]);
+            parameters.put(key, value);
+        }
+        return parameters;
+    }
+
+    /**
+     * Convert version to String.
+     * @return Version definition.
+     */
+    private String versionToString() {
+        if (version == null) {
+            return "";
+        }
+        return "v=" + version;
+    }
+
+    /**
+     * Convert parameters to String.
+     * @return Parameters definition.
+     */
+    private String parametersToString() {
+        if (parameters == null || parameters.isEmpty()) {
+            return "";
+        }
+        List<String> parts = new ArrayList<>();
+        Integer memory = parameters.get("m");
+        if (memory != null) {
+            parts.add("m=" + memory);
+        }
+        Integer iterations = parameters.get("t");
+        if (iterations != null) {
+            parts.add("t=" + iterations);
+        }
+        Integer parallelism = parameters.get("p");
+        if (parallelism != null) {
+            parts.add("p=" + parallelism);
+        }
+        return String.join(",", parts);
+    }
+
+    /**
+     * Convert Argon2 hash to String in Modular Crypt Format.
+     * @return Argon2 hash in Modular Crypt Format
+     */
+    @Override
+    public String toString() {
+        return "$" + algorithm
+                + "$" + versionToString()
+                + "$" + parametersToString()
+                + "$" + BaseEncoding.base64().encode(salt)
+                + "$" + BaseEncoding.base64().encode(digest);
+    }
+}

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/Argon2Hash.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/Argon2Hash.java
@@ -51,7 +51,7 @@ public class Argon2Hash {
     /**
      * Construct Argon2 parameters from definition in Modular Crypt Format.
      * @param input Definition in Modular Crypt Format.
-     * @return Argon2 parameters instance.
+     * @return Argon2 hash instance.
      * @throws IOException In case parsing of hash fails.
      */
     public static Argon2Hash parse(String input) throws IOException {

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/RecoveryInfo.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/RecoveryInfo.java
@@ -1,0 +1,109 @@
+/*
+ * PowerAuth Crypto Library
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.crypto.lib.model;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Class representing recovery code, recovery PUKs and optional seed information.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class RecoveryInfo {
+
+    private String recoveryCode;
+    private Map<Integer, String> puks = new LinkedHashMap<>();
+    private RecoverySeed seed;
+
+    /**
+     * Default contructor.
+     */
+    public RecoveryInfo() {
+    }
+
+    /**
+     * Constructor with recovery code and PUKs.
+     * @param recoveryCode Recovery code.
+     * @param puks PUKs.
+     */
+    public RecoveryInfo(String recoveryCode, Map<Integer, String> puks) {
+        this.recoveryCode = recoveryCode;
+        this.puks = new LinkedHashMap<>(puks);
+    }
+
+    /**
+     * Constructor with recovery code, PUKs and seed.
+     * @param recoveryCode Recovery code.
+     * @param puks Recovery PUKs.
+     * @param seed Recovery seed.
+     */
+    public RecoveryInfo(String recoveryCode, Map<Integer, String> puks, RecoverySeed seed) {
+        this.recoveryCode = recoveryCode;
+        this.puks = puks;
+        this.seed = seed;
+    }
+
+    /**
+     * Get recovery code.
+     * @return Recovery code.
+     */
+    public String getRecoveryCode() {
+        return recoveryCode;
+    }
+
+    /**
+     * Set recovery code.
+     * @param recoveryCode Recovery code.
+     */
+    public void setRecoveryCode(String recoveryCode) {
+        this.recoveryCode = recoveryCode;
+    }
+
+    /**
+     * Get recovery PUKs.
+     * @return Recovery PUKs.
+     */
+    public Map<Integer, String> getPuks() {
+        return puks;
+    }
+
+    /**
+     * Set recovery PUKs.
+     * @param puks Recovery PUKs.
+     */
+    public void setPuks(Map<Integer, String> puks) {
+        this.puks = puks;
+    }
+
+    /**
+     * Get recovery seed.
+     * @return Recovery seed.
+     */
+    public RecoverySeed getSeed() {
+        return seed;
+    }
+
+    /**
+     * Set recovery seed.
+     * @param seed Recovery seed.
+     */
+    public void setSeed(RecoverySeed seed) {
+        this.seed = seed;
+    }
+
+}

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/RecoveryInfo.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/RecoveryInfo.java
@@ -54,7 +54,7 @@ public class RecoveryInfo {
      */
     public RecoveryInfo(String recoveryCode, Map<Integer, String> puks, RecoverySeed seed) {
         this.recoveryCode = recoveryCode;
-        this.puks = puks;
+        this.puks = new LinkedHashMap<>(puks);
         this.seed = seed;
     }
 
@@ -79,7 +79,7 @@ public class RecoveryInfo {
      * @return Recovery PUKs.
      */
     public Map<Integer, String> getPuks() {
-        return puks;
+        return new LinkedHashMap<>(puks);
     }
 
     /**
@@ -87,7 +87,7 @@ public class RecoveryInfo {
      * @param puks Recovery PUKs.
      */
     public void setPuks(Map<Integer, String> puks) {
-        this.puks = puks;
+        this.puks = new LinkedHashMap<>(puks);
     }
 
     /**

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/RecoverySeed.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/RecoverySeed.java
@@ -1,0 +1,79 @@
+/*
+ * PowerAuth Crypto Library
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.crypto.lib.model;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Class representing recovery code seed information.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class RecoverySeed {
+
+    private byte[] nonce;
+    private Map<Integer, Long> pukDerivationIndexes = new LinkedHashMap<>();
+
+    /**
+     * Default constructor.
+     */
+    public RecoverySeed() {
+    }
+
+    /**
+     * Constructor with nonce bytes and PUK derivation indexes.
+     * @param nonce Nonce.
+     * @param pukDerivationIndexes PUK derivation indexes.
+     */
+    public RecoverySeed(byte[] nonce, Map<Integer, Long> pukDerivationIndexes) {
+        this.nonce = nonce;
+        this.pukDerivationIndexes = new LinkedHashMap<>(pukDerivationIndexes);
+    }
+
+    /**
+     * Get nonce bytes.
+     * @return Nonce bytes.
+     */
+    public byte[] getNonce() {
+        return nonce;
+    }
+
+    /**
+     * Set nonce bytes.
+     * @param nonce Nonce bytes.
+     */
+    public void setNonce(byte[] nonce) {
+        this.nonce = nonce;
+    }
+
+    /**
+     * Get PUK derivation indexes.
+     * @return PUK derivation indexes.
+     */
+    public Map<Integer, Long> getPukDerivationIndexes() {
+        return pukDerivationIndexes;
+    }
+
+    /**
+     * Set PUK derivation indexes.
+     * @param pukDerivationIndexes PUK derivation indexes.
+     */
+    public void setPukDerivationIndexes(Map<Integer, Long> pukDerivationIndexes) {
+        this.pukDerivationIndexes = new LinkedHashMap<>(pukDerivationIndexes);
+    }
+}

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/RecoverySeed.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/RecoverySeed.java
@@ -66,7 +66,7 @@ public class RecoverySeed {
      * @return PUK derivation indexes.
      */
     public Map<Integer, Long> getPukDerivationIndexes() {
-        return pukDerivationIndexes;
+        return new LinkedHashMap<>(pukDerivationIndexes);
     }
 
     /**

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/PasswordHash.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/PasswordHash.java
@@ -90,7 +90,7 @@ public class PasswordHash {
         Argon2Parameters.Builder builder = new Argon2Parameters.Builder(algorithmId)
                 .withVersion(input.getVersion())
                 .withIterations(input.getIterations())
-                .withMemoryAsKB(input.getMemory() / 1024)
+                .withMemoryAsKB(input.getMemory())
                 .withParallelism(input.getParallelism())
                 .withSalt(input.getSalt());
         Argon2Parameters parameters = builder.build();

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/PasswordHash.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/PasswordHash.java
@@ -1,0 +1,115 @@
+/*
+ * PowerAuth Crypto Library
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.crypto.lib.util;
+
+import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.crypto.lib.model.Argon2Hash;
+import org.bouncycastle.crypto.generators.Argon2BytesGenerator;
+import org.bouncycastle.crypto.params.Argon2Parameters;
+
+/**
+ * Utility class that provides password hashing functionality using the Argon2i algorithm.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PasswordHash {
+
+    private static final String ALGORITHM_NAME = "argon2i";
+    private static final int ALGORITHM_ID = org.bouncycastle.crypto.params.Argon2Parameters.ARGON2_i;
+    private static final int VERSION = org.bouncycastle.crypto.params.Argon2Parameters.ARGON2_VERSION_13;
+    private static final int ITERATIONS = 3;
+    private static final int MEMORY_POW_2 = 15;
+    private static final int PARALLELISM = 16;
+
+    private static KeyGenerator keyGenerator = new KeyGenerator();
+
+    /**
+     * Generate hash in Argon2 Modular Crypt Format for specified password using Argon2i algorithm.
+     * @param password Password bytes.
+     * @return Hash String in Argon2 Modular Crypt Format.
+     */
+    public static String hash(byte[] password) {
+        Argon2Hash argon2Hash = hash(password, null);
+        return argon2Hash.toString();
+    }
+
+    /**
+     * Verify password hash for specified password and password hash in Modular Crypt Format.
+     * @param password Password bytes for verification.
+     * @param argon2Hash Password hash in Argon2 Modular Crypt Format.
+     * @return Whether password verification succeeded.
+     */
+    public static boolean verify(byte[] password, String argon2Hash) {
+        Argon2Hash inputHash = Argon2Hash.parse(argon2Hash);
+        if (inputHash == null) {
+            return false;
+        }
+        // Verify algorithm name
+        if (!ALGORITHM_NAME.equals(inputHash.getAlgorithm())) {
+            return false;
+        }
+        // Verify algorithm version
+        if (inputHash.getVersion() != VERSION) {
+            return false;
+        }
+        // Verify iteration count
+        if (inputHash.getIterations() != ITERATIONS) {
+            return false;
+        }
+        // Extract salt from supplied hash
+        byte[] salt = inputHash.getSalt();
+        // Compute password digest
+        Argon2Hash expectedHash = hash(password, salt);
+        // Compare hash values
+        return inputHash.hashEquals(expectedHash);
+    }
+
+    /**
+     * Generate password hash in Argon2 Modular Crypt Format for specified password and salt using Argon2i algorithm..
+     * @param password Password bytes.
+     * @param salt Salt bytes, use null for random salt.
+     * @return Argon2 password hash.
+     */
+    private static Argon2Hash hash(byte[] password, byte[] salt) {
+        // In case salt is not specified, generate a random 8-byte salt
+        if (salt == null) {
+            salt = keyGenerator.generateRandomBytes(8);
+        }
+
+        // Set up the Argon2i algorithm
+        Argon2Parameters.Builder builder = new org.bouncycastle.crypto.params.Argon2Parameters.Builder(ALGORITHM_ID)
+                .withVersion(VERSION)
+                .withIterations(ITERATIONS)
+                .withMemoryPowOfTwo(MEMORY_POW_2)
+                .withParallelism(PARALLELISM)
+                .withSalt(salt);
+        Argon2Parameters parameters = builder.build();
+
+        // Generate password digest
+        Argon2BytesGenerator gen = new Argon2BytesGenerator();
+        gen.init(parameters);
+        byte[] digest = new byte[32];
+        gen.generateBytes(password, digest);
+
+        // Convert algorithm parameters and digest to Argon2 Modular Crypt Format
+        Argon2Hash result = new Argon2Hash(ALGORITHM_NAME);
+        result.setParameters(parameters);
+        result.setDigest(digest);
+        return result;
+    }
+
+}

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/PasswordHash.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/PasswordHash.java
@@ -79,7 +79,15 @@ public class PasswordHash {
         if (input == null) {
             return false;
         }
-        Argon2Parameters.Builder builder = new Argon2Parameters.Builder()
+        // Convert algorithm name to algorithm ID
+        int algorithmId = Argon2Parameters.ARGON2_i;
+        for (Map.Entry<Integer, String> entry: ALGORITHM_NAME_MAP.entrySet()) {
+            if (entry.getValue().equals(input.getAlgorithm())) {
+                algorithmId = entry.getKey();
+                break;
+            }
+        }
+        Argon2Parameters.Builder builder = new Argon2Parameters.Builder(algorithmId)
                 .withVersion(input.getVersion())
                 .withIterations(input.getIterations())
                 .withMemoryAsKB(input.getMemory() / 1024)

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/PasswordHash.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/PasswordHash.java
@@ -21,6 +21,7 @@ import io.getlime.security.powerauth.crypto.lib.model.Argon2Hash;
 import org.bouncycastle.crypto.generators.Argon2BytesGenerator;
 import org.bouncycastle.crypto.params.Argon2Parameters;
 
+import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -73,8 +74,9 @@ public class PasswordHash {
      * @param password Password bytes for verification.
      * @param argon2Hash Password hash in Argon2 Modular Crypt Format.
      * @return Whether password verification succeeded.
+     * @throws IOException In case parsing of hash fails.
      */
-    public static boolean verify(byte[] password, String argon2Hash) {
+    public static boolean verify(byte[] password, String argon2Hash) throws IOException {
         Argon2Hash input = Argon2Hash.parse(argon2Hash);
         if (input == null) {
             return false;

--- a/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/activation/PowerAuthRecoveryCodeTest.java
+++ b/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/activation/PowerAuthRecoveryCodeTest.java
@@ -1,0 +1,95 @@
+/*
+ * PowerAuth Crypto Library
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.crypto.activation;
+
+import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
+import io.getlime.security.powerauth.crypto.lib.generator.IdentifierGenerator;
+import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.crypto.lib.model.RecoveryInfo;
+import io.getlime.security.powerauth.crypto.lib.model.RecoverySeed;
+import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import io.getlime.security.powerauth.provider.CryptoProviderUtilFactory;
+import io.getlime.security.powerauth.provider.exception.CryptoProviderException;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.crypto.SecretKey;
+import java.security.*;
+import java.util.HashSet;
+
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PowerAuthRecoveryCodeTest {
+
+    private IdentifierGenerator identifierGenerator = new IdentifierGenerator();
+
+    /**
+     * Add crypto providers.
+     */
+    @Before
+    public void setUp() {
+        // Add Bouncy Castle Security Provider
+        Security.addProvider(new BouncyCastleProvider());
+        PowerAuthConfiguration.INSTANCE.setKeyConvertor(CryptoProviderUtilFactory.getCryptoProviderUtils());
+    }
+
+    @Test
+    public void testRecoveryCodeDerivation() throws CryptoProviderException, InvalidKeyException, GenericCryptoException {
+        // Number of PUKs to test
+        int pukCount = 100;
+
+        // Generate random secret key using ECDH
+        KeyGenerator keyGenerator = new KeyGenerator();
+        KeyPair keyPair1 = keyGenerator.generateKeyPair();
+        PrivateKey privateKey1 = keyPair1.getPrivate();
+        KeyPair keyPair2 = keyGenerator.generateKeyPair();
+        PublicKey publicKey2 = keyPair2.getPublic();
+        SecretKey secretKey = keyGenerator.computeSharedKey(privateKey1, publicKey2, true);
+
+        // Generate recovery code and PUKs using secret key with seed information
+        RecoveryInfo recoveryInfo = identifierGenerator.generateRecoveryCode(secretKey, pukCount, true);
+        assertNotNull(recoveryInfo.getRecoveryCode());
+        assertTrue(identifierGenerator.validateActivationCode(recoveryInfo.getRecoveryCode()));
+        assertNotNull(recoveryInfo.getPuks());
+        assertEquals(pukCount, recoveryInfo.getPuks().size());
+
+        // Verify recovery seed
+        RecoverySeed recoverySeed = recoveryInfo.getSeed();
+        assertNotNull(recoverySeed.getNonce());
+        assertNotNull(recoverySeed.getPukDerivationIndexes());
+        assertEquals(pukCount, recoverySeed.getPukDerivationIndexes().size());
+        assertEquals(recoveryInfo.getPuks().keySet(), recoverySeed.getPukDerivationIndexes().keySet());
+
+        // Verify that PUK derivation indexes are unique
+        assertEquals(pukCount, new HashSet<>(recoverySeed.getPukDerivationIndexes().values()).size());
+
+        // Derive recovery code and PUKs using seed
+        RecoveryInfo derivedRecoveryInfo = identifierGenerator.deriveRecoveryCode(secretKey, recoverySeed);
+
+        // Verify that derive recovery code and PUKs match generated values
+        assertEquals(recoveryInfo.getRecoveryCode(), derivedRecoveryInfo.getRecoveryCode());
+        for (int i = 1; i <= pukCount; i++) {
+            assertEquals(recoveryInfo.getPuks().get(i), derivedRecoveryInfo.getPuks().get(i));
+        }
+    }
+
+}

--- a/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/lib/util/Argon2Test.java
+++ b/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/lib/util/Argon2Test.java
@@ -1,0 +1,90 @@
+/*
+ * PowerAuth Crypto Library
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.crypto.lib.util;
+
+import com.google.common.io.BaseEncoding;
+import io.getlime.security.powerauth.crypto.lib.model.Argon2Hash;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Verify parsing of Argon2 hashes in Modular Crypt Format.
+ */
+public class Argon2Test {
+
+    @Test
+    public void testArgon2HashParser() {
+        // Version 16 test
+        Argon2Hash hash16 = Argon2Hash.parse("$argon2i$m=65536,t=2,p=1$c29tZXNhbHQ$9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ");
+        assertEquals("argon2i", hash16.getAlgorithm());
+        assertNull(hash16.getVersion());
+        assertEquals(65536, (int) hash16.getMemory());
+        assertEquals(2, (int) hash16.getIterations());
+        assertEquals(1, (int) hash16.getParallelism());
+        assertArrayEquals(BaseEncoding.base64().decode("c29tZXNhbHQ"), hash16.getSalt());
+        assertArrayEquals(BaseEncoding.base64().decode("9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ"), hash16.getDigest());
+        // Version 19 test
+        Argon2Hash hash19 = Argon2Hash.parse("$argon2i$v=19$m=65536,t=2,p=1$c29tZXNhbHQ$wWKIMhR9lyDFvRz9YTZweHKfbftvj+qf+YFY4NeBbtA");
+        assertEquals("argon2i", hash19.getAlgorithm());
+        assertEquals(19, (int) hash19.getVersion());
+        assertEquals(65536, (int) hash19.getMemory());
+        assertEquals(2, (int) hash19.getIterations());
+        assertEquals(1, (int) hash19.getParallelism());
+        assertArrayEquals(BaseEncoding.base64().decode("c29tZXNhbHQ"), hash19.getSalt());
+        assertArrayEquals(BaseEncoding.base64().decode("wWKIMhR9lyDFvRz9YTZweHKfbftvj+qf+YFY4NeBbtA"), hash19.getDigest());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidHash1() {
+        Argon2Hash.parse("argon2i$v=19$m=65536,t=2,p=1$c29tZXNhbHQ$wWKIMhR9lyDFvRz9YTZweHKfbftvj+qf+YFY4NeBbtA");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidHash2() {
+        Argon2Hash.parse("$argon2i$v=19$c29tZXNhbHQ$wWKIMhR9lyDFvRz9YTZweHKfbftvj+qf+YFY4NeBbtA");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidHash3() {
+        Argon2Hash.parse("argon2i$v=19$m=65536,t=2,p=1$$wWKIMhR9lyDFvRz9YTZweHKfbftvj+qf+YFY4NeBbtA");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidHash4() {
+        Argon2Hash.parse("$argon2i$v=19$m=65536,t=2,p=1$c29tZXNhbHQ$");
+    }
+
+    @Test
+    public void testArgon2HashGenerator() {
+        Argon2Hash hash19 = new Argon2Hash("argon2i");
+        hash19.setVersion(19);
+        hash19.setMemory(32768);
+        hash19.setParallelism(16);
+        hash19.setIterations(5);
+        hash19.setSalt(BaseEncoding.base64().decode("c29tZXNhbHQ"));
+        hash19.setDigest(BaseEncoding.base64().decode("iekCn0Y3spW+sCcFanM2xBT63UP2sghkUoHLIUpWRS8"));
+        assertEquals("$argon2i$v=19$m=32768,t=5,p=16$c29tZXNhbHQ$iekCn0Y3spW+sCcFanM2xBT63UP2sghkUoHLIUpWRS8", hash19.toString());
+        Argon2Hash hash16 = new Argon2Hash("argon2id");
+        hash16.setMemory(256);
+        hash16.setParallelism(2);
+        hash16.setIterations(2);
+        hash16.setSalt(BaseEncoding.base64().decode("c29tZXNhbHQ"));
+        hash16.setDigest(BaseEncoding.base64().decode("bQk8UB/VmZZF4Oo79iDXuL5/0ttZwg2f/5U52iv1cDc"));
+        assertEquals("$argon2id$m=256,t=2,p=2$c29tZXNhbHQ$bQk8UB/VmZZF4Oo79iDXuL5/0ttZwg2f/5U52iv1cDc", hash16.toString());
+    }
+}

--- a/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/lib/util/Argon2Test.java
+++ b/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/lib/util/Argon2Test.java
@@ -20,6 +20,8 @@ import com.google.common.io.BaseEncoding;
 import io.getlime.security.powerauth.crypto.lib.model.Argon2Hash;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static org.junit.Assert.*;
 
 /**
@@ -28,7 +30,7 @@ import static org.junit.Assert.*;
 public class Argon2Test {
 
     @Test
-    public void testArgon2HashParser() {
+    public void testArgon2HashParser() throws IOException {
         // Version 16 test
         Argon2Hash hash16 = Argon2Hash.parse("$argon2i$m=65536,t=2,p=1$c29tZXNhbHQ$9sTbSlTio3Biev89thdrlKKiCaYsjjYVJxGAL3swxpQ");
         assertEquals("argon2i", hash16.getAlgorithm());
@@ -49,23 +51,23 @@ public class Argon2Test {
         assertArrayEquals(BaseEncoding.base64().decode("wWKIMhR9lyDFvRz9YTZweHKfbftvj+qf+YFY4NeBbtA"), hash19.getDigest());
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidHash1() {
+    @Test(expected = IOException.class)
+    public void testInvalidHash1() throws IOException {
         Argon2Hash.parse("argon2i$v=19$m=65536,t=2,p=1$c29tZXNhbHQ$wWKIMhR9lyDFvRz9YTZweHKfbftvj+qf+YFY4NeBbtA");
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidHash2() {
+    @Test(expected = IOException.class)
+    public void testInvalidHash2() throws IOException {
         Argon2Hash.parse("$argon2i$v=19$c29tZXNhbHQ$wWKIMhR9lyDFvRz9YTZweHKfbftvj+qf+YFY4NeBbtA");
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidHash3() {
+    @Test(expected = IOException.class)
+    public void testInvalidHash3() throws IOException {
         Argon2Hash.parse("argon2i$v=19$m=65536,t=2,p=1$$wWKIMhR9lyDFvRz9YTZweHKfbftvj+qf+YFY4NeBbtA");
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidHash4() {
+    @Test(expected = IOException.class)
+    public void testInvalidHash4() throws IOException {
         Argon2Hash.parse("$argon2i$v=19$m=65536,t=2,p=1$c29tZXNhbHQ$");
     }
 

--- a/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/lib/util/PasswordHashTest.java
+++ b/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/lib/util/PasswordHashTest.java
@@ -21,24 +21,19 @@ import org.junit.Test;
 import java.nio.charset.StandardCharsets;
 
 /**
- * Verify various passwords against Argon2i hashes generated using command line utility.
+ * Test verification of Argon2 hashes.
  */
 public class PasswordHashTest {
 
     @Test
     public void testArgon2Hashes() {
+        System.out.println("Testing Argon2 hash verification using various passwords.");
         PasswordHash.verify("".getBytes(StandardCharsets.UTF_8),
                 "$argon2i$v=19$m=32768,t=3,p=16$VFo3SnVYSnk$WZrqp36HmoSPeGhVCt5Ly3s9pU1OpnRnJMPjnlVcdy8");
         PasswordHash.verify("maC2kBxu".getBytes(StandardCharsets.UTF_8),
                 "$argon2i$v=19$m=32768,t=3,p=16$YndXNDhGV0o$E2cHqAeGlUyO26haRT/a7VPzcSeLbISimR98F7CAooI");
-        PasswordHash.verify("PFhd5jR6".getBytes(StandardCharsets.UTF_8),
-                "$argon2i$v=19$m=32768,t=3,p=16$VTdEWXFjNVQ$Ejgk/eNZnH6yEbGOUlo/T0fV578oX9B6f+EjeP6iE7I");
-        PasswordHash.verify("YYwgb7p8".getBytes(StandardCharsets.UTF_8),
-                "$argon2i$v=19$m=32768,t=3,p=16$SDdTczlSaFA$hEPOgZDyofKWcpnPEvoSzPVyeuydHFKiB6aK055FA34");
         PasswordHash.verify("EbyBt7U4djF6G84Y".getBytes(StandardCharsets.UTF_8),
                 "$argon2i$v=19$m=32768,t=3,p=16$UjN6elpVcGI$cRyh9e5nfu6ToXKR1pbPiFudEenRYYuvgea4hvsTB0Y");
-        PasswordHash.verify("XhYb2E93LwQeEm9E".getBytes(StandardCharsets.UTF_8),
-                "$argon2i$v=19$m=32768,t=3,p=16$bVVyNHc2U24$qEkfGgPJ5JzhozbgitvDMgK2Kl8vj7mYvUbjI76NgzE");
         PasswordHash.verify("The quick brown fox jumps over the lazy dog.".getBytes(StandardCharsets.UTF_8),
                 "$argon2i$v=19$m=32768,t=3,p=16$a3c5RzYzOXo$LLM1F2EBBKjuoUc3CRlPNsmGI3vc3mnvNmafao8askc");
         PasswordHash.verify("Příliš žluťoučký kůň úpěl ďábelské ódy.".getBytes(StandardCharsets.UTF_8),
@@ -47,4 +42,22 @@ public class PasswordHashTest {
                 "$argon2i$v=19$m=32768,t=3,p=16$eTZQV0NuVWU$Xi8HXgnunRNBRjH+U5mXEUC7b9uX1JnWVYZtHMzQYmg");
     }
 
+    @Test
+    public void testArgon2DifferentParameters() {
+        System.out.println("Testing Argon2 hash verification using various algorithm parameters.");
+        PasswordHash.verify("password".getBytes(StandardCharsets.UTF_8),
+                "$argon2i$v=19$m=65536,t=2,p=1$c29tZXNhbHQ$wWKIMhR9lyDFvRz9YTZweHKfbftvj+qf+YFY4NeBbtA");
+        PasswordHash.verify("password".getBytes(StandardCharsets.UTF_8),
+                "$argon2i$v=19$m=256,t=2,p=1$c29tZXNhbHQ$iekCn0Y3spW+sCcFanM2xBT63UP2sghkUoHLIUpWRS8");
+        PasswordHash.verify("password".getBytes(StandardCharsets.UTF_8),
+                "$argon2i$v=19$m=256,t=2,p=2$c29tZXNhbHQ$T/XOJ2mh1/TIpJHfCdQan76Q5esCFVoT5MAeIM1Oq2E");
+        PasswordHash.verify("password".getBytes(StandardCharsets.UTF_8),
+                "$argon2i$v=19$m=65536,t=1,p=1$c29tZXNhbHQ$0WgHXE2YXhPr6uVgz4uUw7XYoWxRkWtvSsLaOsEbvs8");
+    }
+
+    @Test
+    public void testArgon2id() {
+        System.out.println("Testing Argon2 hash verification using Argon2id algorithm.");
+        PasswordHash.verify("password".getBytes(StandardCharsets.UTF_8), "$argon2id$v=19$m=256,t=2,p=2$c29tZXNhbHQ$bQk8UB/VmZZF4Oo79iDXuL5/0ttZwg2f/5U52iv1cDc");
+    }
 }

--- a/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/lib/util/PasswordHashTest.java
+++ b/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/lib/util/PasswordHashTest.java
@@ -18,6 +18,7 @@ package io.getlime.security.powerauth.crypto.lib.util;
 
 import org.junit.Test;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -26,7 +27,7 @@ import java.nio.charset.StandardCharsets;
 public class PasswordHashTest {
 
     @Test
-    public void testArgon2Hashes() {
+    public void testArgon2Hashes() throws IOException {
         System.out.println("Testing Argon2 hash verification using various passwords.");
         PasswordHash.verify("".getBytes(StandardCharsets.UTF_8),
                 "$argon2i$v=19$m=32768,t=3,p=16$VFo3SnVYSnk$WZrqp36HmoSPeGhVCt5Ly3s9pU1OpnRnJMPjnlVcdy8");
@@ -43,7 +44,7 @@ public class PasswordHashTest {
     }
 
     @Test
-    public void testArgon2DifferentParameters() {
+    public void testArgon2DifferentParameters() throws IOException {
         System.out.println("Testing Argon2 hash verification using various algorithm parameters.");
         PasswordHash.verify("password".getBytes(StandardCharsets.UTF_8),
                 "$argon2i$v=19$m=65536,t=2,p=1$c29tZXNhbHQ$wWKIMhR9lyDFvRz9YTZweHKfbftvj+qf+YFY4NeBbtA");
@@ -56,7 +57,7 @@ public class PasswordHashTest {
     }
 
     @Test
-    public void testArgon2id() {
+    public void testArgon2id() throws IOException {
         System.out.println("Testing Argon2 hash verification using Argon2id algorithm.");
         PasswordHash.verify("password".getBytes(StandardCharsets.UTF_8), "$argon2id$v=19$m=256,t=2,p=2$c29tZXNhbHQ$bQk8UB/VmZZF4Oo79iDXuL5/0ttZwg2f/5U52iv1cDc");
     }

--- a/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/lib/util/PasswordHashTest.java
+++ b/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/lib/util/PasswordHashTest.java
@@ -1,0 +1,50 @@
+/*
+ * PowerAuth Crypto Library
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.crypto.lib.util;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Verify various passwords against Argon2i hashes generated using command line utility.
+ */
+public class PasswordHashTest {
+
+    @Test
+    public void testArgon2Hashes() {
+        PasswordHash.verify("".getBytes(StandardCharsets.UTF_8),
+                "$argon2i$v=19$m=32768,t=3,p=16$VFo3SnVYSnk$WZrqp36HmoSPeGhVCt5Ly3s9pU1OpnRnJMPjnlVcdy8");
+        PasswordHash.verify("maC2kBxu".getBytes(StandardCharsets.UTF_8),
+                "$argon2i$v=19$m=32768,t=3,p=16$YndXNDhGV0o$E2cHqAeGlUyO26haRT/a7VPzcSeLbISimR98F7CAooI");
+        PasswordHash.verify("PFhd5jR6".getBytes(StandardCharsets.UTF_8),
+                "$argon2i$v=19$m=32768,t=3,p=16$VTdEWXFjNVQ$Ejgk/eNZnH6yEbGOUlo/T0fV578oX9B6f+EjeP6iE7I");
+        PasswordHash.verify("YYwgb7p8".getBytes(StandardCharsets.UTF_8),
+                "$argon2i$v=19$m=32768,t=3,p=16$SDdTczlSaFA$hEPOgZDyofKWcpnPEvoSzPVyeuydHFKiB6aK055FA34");
+        PasswordHash.verify("EbyBt7U4djF6G84Y".getBytes(StandardCharsets.UTF_8),
+                "$argon2i$v=19$m=32768,t=3,p=16$UjN6elpVcGI$cRyh9e5nfu6ToXKR1pbPiFudEenRYYuvgea4hvsTB0Y");
+        PasswordHash.verify("XhYb2E93LwQeEm9E".getBytes(StandardCharsets.UTF_8),
+                "$argon2i$v=19$m=32768,t=3,p=16$bVVyNHc2U24$qEkfGgPJ5JzhozbgitvDMgK2Kl8vj7mYvUbjI76NgzE");
+        PasswordHash.verify("The quick brown fox jumps over the lazy dog.".getBytes(StandardCharsets.UTF_8),
+                "$argon2i$v=19$m=32768,t=3,p=16$a3c5RzYzOXo$LLM1F2EBBKjuoUc3CRlPNsmGI3vc3mnvNmafao8askc");
+        PasswordHash.verify("Příliš žluťoučký kůň úpěl ďábelské ódy.".getBytes(StandardCharsets.UTF_8),
+                "$argon2i$v=19$m=32768,t=3,p=16$cTZ5NUtYNFg$ma0FJ8SJ/U1YXZ4pmtOMgF23WfodzNEIizke8zG+Auc");
+        PasswordHash.verify("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.".getBytes(StandardCharsets.UTF_8),
+                "$argon2i$v=19$m=32768,t=3,p=16$eTZQV0NuVWU$Xi8HXgnunRNBRjH+U5mXEUC7b9uX1JnWVYZtHMzQYmg");
+    }
+
+}

--- a/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtil.java
+++ b/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtil.java
@@ -34,7 +34,7 @@ public interface CryptoProviderUtil {
     /**
      * Get the provider name, for example "BC" for Bouncy Castle.
      *
-     * @return Name of the provider, for example "BC" for Boucy Castle.
+     * @return Name of the provider, for example "BC" for Bouncy Castle.
      */
     String getProviderName();
 

--- a/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtilBouncyCastle.java
+++ b/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtilBouncyCastle.java
@@ -42,7 +42,7 @@ public class CryptoProviderUtilBouncyCastle implements CryptoProviderUtil {
     /**
      * Get the provider name, for example "BC" for Bouncy Castle.
      *
-     * @return Name of the provider, for example "BC" for Boucy Castle.
+     * @return Name of the provider, for example "BC" for Bouncy Castle.
      */
     @Override
     public String getProviderName() {

--- a/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtilsSpongyCastle.java
+++ b/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtilsSpongyCastle.java
@@ -42,7 +42,7 @@ public class CryptoProviderUtilsSpongyCastle implements CryptoProviderUtil {
     /**
      * Get the provider name, for example "BC" for Bouncy Castle.
      *
-     * @return Name of the provider, for example "BC" for Boucy Castle.
+     * @return Name of the provider, for example "BC" for Bouncy Castle.
      */
     @Override
     public String getProviderName() {


### PR DESCRIPTION
The pull request contains following changes:
- Fix #250: Hashing function for storing PUK values in recovery codes
- Added `sharedInfo1` parameter for recovery code confirmation
- Recovery code generation and derivation
- Tests for password hashing and recovery code generation and derivation
- Added dependency on Bouncy Castle for Argon2 support
- Documentation updates