### PR TITLE
Fix #252: Detect duplicate PUKs when generating recovery codes

### DIFF
--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/IdentifierGenerator.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/IdentifierGenerator.java
@@ -224,7 +224,7 @@ public class IdentifierGenerator {
             Long derivationIndex;
             String derivedPuk;
             do {
-                // Generate random derivation index which must be unique
+                // Generate random derivation index
                 derivationIndexBytes = keyGenerator.generateRandomBytes(8);
                 derivationIndex = ByteBuffer.wrap(derivationIndexBytes).getLong();
                 // Generate recovery PUK

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/IdentifierGenerator.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/IdentifierGenerator.java
@@ -220,12 +220,11 @@ public class IdentifierGenerator {
         final Map<Integer, String> puks = new LinkedHashMap<>();
 
         for (int i = 1; i <= pukCount; i++) {
-            byte[] derivationIndexBytes;
             Long derivationIndex;
             String derivedPuk;
             do {
                 // Generate random derivation index
-                derivationIndexBytes = keyGenerator.generateRandomBytes(8);
+                byte[] derivationIndexBytes = keyGenerator.generateRandomBytes(8);
                 derivationIndex = ByteBuffer.wrap(derivationIndexBytes).getLong();
                 // Generate recovery PUK
                 derivedPuk = generatePuk(recoveryPukBaseKey, derivationIndexBytes);

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/IdentifierGenerator.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/IdentifierGenerator.java
@@ -222,15 +222,18 @@ public class IdentifierGenerator {
         for (int i = 1; i <= pukCount; i++) {
             byte[] derivationIndexBytes;
             Long derivationIndex;
+            String derivedPuk;
             do {
                 // Generate random derivation index which must be unique
                 derivationIndexBytes = keyGenerator.generateRandomBytes(8);
                 derivationIndex = ByteBuffer.wrap(derivationIndexBytes).getLong();
-            } while (pukDerivationIndexes.values().contains(derivationIndex));
+                // Generate recovery PUK
+                derivedPuk = generatePuk(recoveryPukBaseKey, derivationIndexBytes);
+                // Make sure that generated PUK is unique
+            } while (puks.values().contains(derivedPuk));
 
-            // Generate recovery PUK and store it including derivation index
-            String pukDerived = generatePuk(recoveryPukBaseKey, derivationIndexBytes);
-            puks.put(i, pukDerived);
+            // Store generated PUK including its derivation index
+            puks.put(i, derivedPuk);
             pukDerivationIndexes.put(i, derivationIndex);
         }
         if (exportSeed) {


### PR DESCRIPTION
Detection of duplicates is now done on `PUK`s, not on `pukDerivationIndex`es.