### PR TITLE
Fix broken documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A typical use-case for PowerAuth protocol would be assuring the security of a mo
 
 ## Documentation
 
-For the most recent documentation and tutorials, please visit [PowerAuth Crypto Documentation](./docs/Readme.md).
+For the most recent documentation and tutorials, please visit [PowerAuth Crypto Documentation on GitHub](./docs/Readme.md) or visit [developers.wultra.com](https://developers.wultra.com/docs/develop/powerauth-crypto).
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A typical use-case for PowerAuth protocol would be assuring the security of a mo
 
 ## Documentation
 
-For the most recent documentation and tutorials, please visit [PowerAuth Crypto Documentation](https://developers.wultra.com/docs/current/powerauth-crypto/).
+For the most recent documentation and tutorials, please visit [PowerAuth Crypto Documentation](./docs/Readme.md).
 
 # License
 


### PR DESCRIPTION
The `current` version is no longer available in developer portal. I am switching to `./docs/Readme.md` so that we don't have to update links in every release from the main `README.md`.