### PR TITLE
Fix #272: Invalid algorithm specification during key conversion

### DIFF
--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/KeyGenerator.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/generator/KeyGenerator.java
@@ -215,7 +215,7 @@ public class KeyGenerator {
             PBEKeySpec spec = new PBEKeySpec(password.toCharArray(), salt, iterations, 128);
             SecretKeyFactory skf = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1", PowerAuthConfiguration.INSTANCE.getKeyConvertor().getProviderName());
             byte[] keyBytes = skf.generateSecret(spec).getEncoded();
-            return new SecretKeySpec(keyBytes, "AES/ECB/NoPadding");
+            return new SecretKeySpec(keyBytes, "AES");
         } catch (NoSuchAlgorithmException | InvalidKeySpecException | NoSuchProviderException ex) {
             throw new CryptoProviderException(ex.getMessage(), ex);
         }

--- a/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtilBouncyCastle.java
+++ b/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtilBouncyCastle.java
@@ -138,7 +138,7 @@ public class CryptoProviderUtilBouncyCastle implements CryptoProviderUtil {
      * @return An instance of the secret key by decoding from provided bytes.
      */
     public SecretKey convertBytesToSharedSecretKey(byte[] bytesSecretKey) {
-        return new SecretKeySpec(bytesSecretKey, "AES/ECB/NoPadding");
+        return new SecretKeySpec(bytesSecretKey, "AES");
     }
 
 }

--- a/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtilsSpongyCastle.java
+++ b/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtilsSpongyCastle.java
@@ -143,7 +143,7 @@ public class CryptoProviderUtilsSpongyCastle implements CryptoProviderUtil {
      */
     @Override
     public SecretKey convertBytesToSharedSecretKey(byte[] bytesSecretKey) {
-        return new SecretKeySpec(bytesSecretKey, "AES/ECB/NoPadding");
+        return new SecretKeySpec(bytesSecretKey, "AES");
     }
 
 }


### PR DESCRIPTION
According to documentation the algorithm name in `SecretKeySpec` should not specify mode or padding.