### PR TITLE
Fix #278: Update Maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,10 +74,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
-        <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-        <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
-        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
+        <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
+        <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
     </properties>
 
     <build>

--- a/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtil.java
+++ b/powerauth-java-prov/src/main/java/io/getlime/security/powerauth/provider/CryptoProviderUtil.java
@@ -43,6 +43,7 @@ public interface CryptoProviderUtil {
      *
      * @param publicKey An EC public key to be converted.
      * @return A byte array representation of the EC public key.
+     * @throws CryptoProviderException In case crypto provider is not initialized correctly.
      */
     byte[] convertPublicKeyToBytes(PublicKey publicKey) throws CryptoProviderException;
 


### PR DESCRIPTION
Note: Surprisingly, the "M1" dependency is correct here, see [plugin web](https://maven.apache.org/plugins/maven-deploy-plugin/download.cgi) for the details.

> **Apache Maven Deploy Plugin 3.0.0-M1**
> This is the current stable version of Apache Maven Deploy Plugin.