### PR TITLE
Fix #314: Improve logic for unknown signature type

### DIFF
--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/keyfactory/PowerAuthClientKeyFactory.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/client/keyfactory/PowerAuthClientKeyFactory.java
@@ -51,6 +51,10 @@ public class PowerAuthClientKeyFactory {
 
         List<SecretKey> signatureKeys = new ArrayList<>();
 
+        if (signatureType == null) {
+            return signatureKeys;
+        }
+
         if (signatureType.equals(PowerAuthSignatureTypes.POSSESSION)) {
 
             signatureKeys.add(possessionSignatureKey);

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/enums/PowerAuthSignatureTypes.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/enums/PowerAuthSignatureTypes.java
@@ -72,7 +72,7 @@ public enum PowerAuthSignatureTypes {
     }
 
     /**
-     * Get enum value from provided string. In case the provided value does not match any value, POSSESSION_KNOWLEDGE is returned.
+     * Get enum value from provided string. In case the provided value does not match any value, null value is returned.
      * @param value String to get the enum value for.
      * @return Enum value.
      */

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/enums/PowerAuthSignatureTypes.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/enums/PowerAuthSignatureTypes.java
@@ -83,8 +83,8 @@ public enum PowerAuthSignatureTypes {
                 return type;
             }
         }
-        // Otherwise try to guess the most usual suspect...
-        return PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE;
+        // Otherwise return null
+        return null;
     }
 
     /**

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/keyfactory/PowerAuthServerKeyFactory.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/server/keyfactory/PowerAuthServerKeyFactory.java
@@ -54,6 +54,10 @@ public class PowerAuthServerKeyFactory {
 
         List<SecretKey> signatureKeys = new ArrayList<>();
 
+        if (signatureType == null) {
+            return signatureKeys;
+        }
+
         if (signatureType.equals(PowerAuthSignatureTypes.POSSESSION)) {
 
             SecretKey signatureKey = generateServerSignaturePossessionKey(masterSecretKey);


### PR DESCRIPTION
The pull request replaces the guessed signature type with `null` value to avoid unexpected behaviour (e.g. when there is a typo in signature type). See also: https://github.com/wultra/powerauth-restful-integration/pull/231