### PR TITLE
Fix #384: Use BC library for array comparison

### DIFF
--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesDecryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesDecryptor.java
@@ -24,6 +24,7 @@ import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoExc
 import io.getlime.security.powerauth.crypto.lib.util.AESEncryptionUtils;
 import io.getlime.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import io.getlime.security.powerauth.crypto.lib.util.KeyConvertor;
+import io.getlime.security.powerauth.crypto.lib.util.SideChannelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +32,6 @@ import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
 import java.security.PrivateKey;
 import java.security.interfaces.ECPrivateKey;
-import java.util.Arrays;
 
 /**
  * Class implementing an ECIES decryptor.
@@ -222,7 +222,7 @@ public class EciesDecryptor {
             // Validate data MAC value
             final byte[] macData = (sharedInfo2 == null ? cryptogram.getEncryptedData() : Bytes.concat(cryptogram.getEncryptedData(), sharedInfo2));
             final byte[] mac = hmac.hash(envelopeKey.getMacKey(), macData);
-            if (!Arrays.equals(mac, cryptogram.getMac())) {
+            if (!SideChannelUtils.constantTimeAreEqual(mac, cryptogram.getMac())) {
                 throw new EciesException("Invalid MAC");
             }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesEncryptor.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/encryptor/ecies/EciesEncryptor.java
@@ -25,6 +25,7 @@ import io.getlime.security.powerauth.crypto.lib.model.exception.GenericCryptoExc
 import io.getlime.security.powerauth.crypto.lib.util.AESEncryptionUtils;
 import io.getlime.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import io.getlime.security.powerauth.crypto.lib.util.KeyConvertor;
+import io.getlime.security.powerauth.crypto.lib.util.SideChannelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +33,6 @@ import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
 import java.security.PublicKey;
 import java.security.interfaces.ECPublicKey;
-import java.util.Arrays;
 
 /**
  * Class implementing an ECIES encryptor.
@@ -232,7 +232,7 @@ public class EciesEncryptor {
             // Validate data MAC value
             final byte[] macData = (sharedInfo2 == null ? cryptogram.getEncryptedData() : Bytes.concat(cryptogram.getEncryptedData(), sharedInfo2));
             final byte[] mac = hmac.hash(envelopeKey.getMacKey(), macData);
-            if (!Arrays.equals(mac, cryptogram.getMac())) {
+            if (!SideChannelUtils.constantTimeAreEqual(mac, cryptogram.getMac())) {
                 throw new EciesException("Invalid MAC");
             }
 

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/Argon2Hash.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/model/Argon2Hash.java
@@ -17,6 +17,7 @@
 package io.getlime.security.powerauth.crypto.lib.model;
 
 import com.google.common.io.BaseEncoding;
+import io.getlime.security.powerauth.crypto.lib.util.SideChannelUtils;
 
 import java.io.IOException;
 import java.util.*;
@@ -231,7 +232,7 @@ public class Argon2Hash {
         if (digest == null || other.digest == null) {
             return false;
         }
-        return Arrays.equals(digest, other.digest);
+        return SideChannelUtils.constantTimeAreEqual(digest, other.digest);
     }
 
     /**

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/HashBasedCounterUtils.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/HashBasedCounterUtils.java
@@ -104,6 +104,6 @@ public class HashBasedCounterUtils {
         // Calculate hash from current hash based counter
         final byte[] expectedCtrDataHash = calculateHashFromHashBasedCounter(expectedCtrData, transportKey);
         // Compare both hashed values
-        return Arrays.equals(expectedCtrDataHash, receivedCtrDataHash);
+        return SideChannelUtils.constantTimeAreEqual(expectedCtrDataHash, receivedCtrDataHash);
     }
 }

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/SideChannelUtils.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/SideChannelUtils.java
@@ -1,0 +1,41 @@
+/*
+ * PowerAuth Crypto Library
+ * Copyright 2021 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.crypto.lib.util;
+
+import org.bouncycastle.util.Arrays;
+
+/**
+ * Utilities for preventing side channel attacks.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class SideChannelUtils {
+
+    private SideChannelUtils() {
+        
+    }
+
+    /**
+     * Compare two byte arrays in constant time.
+     * @param bytes1 First byte array.
+     * @param bytes2 Second byte array.
+     * @return Whether byte arrays are equal.
+     */
+    public static boolean constantTimeAreEqual(byte[] bytes1, byte[] bytes2) {
+        return Arrays.constantTimeAreEqual(bytes1, bytes2);
+    }
+}

--- a/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/TokenUtils.java
+++ b/powerauth-java-crypto/src/main/java/io/getlime/security/powerauth/crypto/lib/util/TokenUtils.java
@@ -116,7 +116,7 @@ public class TokenUtils {
      * @throws CryptoProviderException In case cryptography provider is incorrectly initialized.
      */
     public boolean validateTokenDigest(byte[] nonce, byte[] timestamp, byte[] tokenSecret, byte[] tokenDigest) throws GenericCryptoException, CryptoProviderException {
-        return Arrays.equals(computeTokenDigest(nonce, timestamp, tokenSecret), tokenDigest);
+        return SideChannelUtils.constantTimeAreEqual(computeTokenDigest(nonce, timestamp, tokenSecret), tokenDigest);
     }
 
 }


### PR DESCRIPTION
Migration to BC library due to constant time array comparisons.