### PR TITLE
Fix #455: Correct test vectors for offline signatures

### DIFF
--- a/powerauth-docs/test-vectors/signatures-offline.json
+++ b/powerauth-docs/test-vectors/signatures-offline.json
@@ -2,2603 +2,2603 @@
   "description" : "Client must be able to compute PowerAuth offline signature (using 1FA, 2FA signature keys) based on given data, counter and signature type",
   "data" : [ {
     "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "4",
-      "counterData" : "9KpKZz2Na+csMwv8QPagqg==",
-      "data" : "/AGs8HwhZgnQjR2os9DQIuVm8rcG92+cfA5Z1MnrvUZ8O3tO997KAAglI9yfT2nTWMU9S1PuuIlFGFPsKeoI63KXgVV0VyFtPq+HeYNP1C6RC5H3joaF1pVIKhnlMubv5TvUdiZp+lnviTubFWdStx5qpAx72sKPz09D49fNyhQSal0iJMhA5YTTR218fOkX140Iw8AAvYf4C7t1NVPtbsAXEb3k6F3MaQ=="
+      "counterData" : "V4uAF/PstuQoGNnNTifHuw==",
+      "data" : "ckWnyNpYHL8oQqkl/FY0jzXDYDCEZG2JdCFl/65b+6qvr62j4jLkNHyg+uM6zhLWjUGmzUD+czPjlIWYCM2mNe5UTaufhd+CjaiwBOiQiX0CVgCjFbjEBTSr6VPSg267D0cmuIVjFsa2Wftbdvf7tnEAMobUzWGLVXawgi+EgkiwoHOuf4jtPqE0j7cSEWBw4mjar+fRA//SY9jj0iGZ1NR6a3Dr02coy/KQV7q51CI+2KOjyIozoqZmepVMvd1F"
     },
     "output" : {
-      "signature" : "64208348"
+      "signature" : "6766"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "4",
-      "counterData" : "4ueSIUpKM5FxMGxrI0nrjQ==",
-      "data" : "3yPs4GASw9Eml8UMMJGom8yuQCL7NcFZGlGBlpgRp1LHGx27PQMhL7VQkj/Fa/sF98oTI1jkB38uxqSZJ30mur4+OPSE8wpZ4WEYMKS5ktyR8RS3bkqrLgGQdzptS065WT33EZl9W+x6zMWZYfPhx40oIuxH6AVAzSH+8KxydiU0NWrk9rNNqjhAImTUMDQ0+c0FEGnAfiGkFklk3Y8mUwbu8xnVb+dahLRBEzdLa3uSS79YVEMTzFRJJ3GK3byo3+vLrtOE5v5kfuVdu1DPGp2qONIoU9Th+67XFuwOTvL5+REcJ366DIVkN1gdPQfTU9wXIw=="
+      "counterData" : "orZ9RZH55L6aCgIj3RVReA==",
+      "data" : "1yzfEaX2"
     },
     "output" : {
-      "signature" : "84711625"
+      "signature" : "8484"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "4",
-      "counterData" : "c3W2SXBUabwRLuC7WIQzmQ==",
-      "data" : "tKvJ5JajAFaPUK9oR/Son6ggc3CGl+zRpwgBEkZWZTZ5m3fhoW6Ye5r6atNr5ZkaeamloaYmv4wZ5TUb4Y6SzUBKz/Qxd/NdwTRe+FRUbHHPE9vRTwYrXkclAIbzTmSsLJY3rEcds9oRBzeDy1eTopv/NzkNjYKl3q8eSM33eNqPOia0Yv98wwVrRwwfUnfK"
+      "counterData" : "ayfObKO450kplewm9vYvmg==",
+      "data" : "jzH9hRasgnajSnT+1mwMXc2+blMzx+6p1Oojx9rh6I0U2wjtu0CHfqjCW82crCQX5xE6liCfptpxqz/c9AsW/7JGxUkv2r4a9J1QidX0NWPRPkwfSbP+8DuXu6Le7fDYE0+Sgg=="
     },
     "output" : {
-      "signature" : "31708557"
+      "signature" : "9714"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "4",
-      "counterData" : "f8EqnazP/cZUyoBR9xhfng==",
-      "data" : "itiaQPMojtYxO4wtuM6O2lzCKL5gd/s="
+      "counterData" : "SNhfHNjw+3FuMjLvHgoDQQ==",
+      "data" : "QUb0d/fSErnkXh4DxatDZA=="
     },
     "output" : {
-      "signature" : "91528615"
+      "signature" : "8871"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "4",
-      "counterData" : "GdKZBkDQsprakUNGmB+LEQ==",
-      "data" : "iEwBSJTDXWfxf+8RtWEP4RHrQQIx6yisFE3JqYYtGkBwWyO5TfIuCMC7QQPGV8PtqIdiTrVM7dnnz6ynlRwjKTA0qbBndPXxHryVU6F+4MJaQHmMvg58SfiJuQsbH9uDNCvZdVVaTyw98iZYJnItNu6a0lhqTuNUsajmLA+CHYETMLazZsjs83XoCI94cWZoKyelhsh8Hs6D96IFkX5fZipPzJvT/+7GG4/VyAc4imnAKAzVcfs1ppEcAg=="
+      "counterData" : "vhwIGP8mjv7BrxO4yVah9w==",
+      "data" : "MB5K2M6F8aZTbMzyBoNW2ReC/hCLOcAblrDzdJxJWy2xpAL5RPragO+u3n/1VhM7KI8VZ+LzbBgkeG1TaHjlsgx2T9tC9QaX1PQ2RKUzyANbaTv/IKQSqyjeegLriVD6+LNpR+ydHW3CqaIYTnfd9hlhFwqLVwMprfh4rjU0O7Af5d70m8Bliw8Ctw=="
     },
     "output" : {
-      "signature" : "17360211"
+      "signature" : "3448"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "4",
-      "counterData" : "M4e0hFnojlw2/Dft02GMFQ==",
-      "data" : "dvbAoXJahd00EP/T+uFPdiEYC2+8igONCRRKV9m6+qKax+TXlbVsNLM+lZu4sUa76VhoETgCIS753po/QsLDZuEahx6fp+B0ieJU7bhiU7mS65fx8+ywM2RRH06LDM5mSkmGXOPcQBtauYhS3Pd40oMj/hAuSGeZGaT6OjA="
+      "counterData" : "gWRhQVJXK1hpxsNsfiwb1g==",
+      "data" : "ah8r7UV78N9Tq3nQHjfP+MhXPuixyyjME4nKK1XZAFsvbdnIDGqcqM+pte1VgNei7VQ54ujrPNsvWyUO18DXkeJ5TPVM00vU8xEZcTHz0KXLuH5Vhn6sHaOHifyBRgzw8eEXu7uW8nu7L37SPU30hsPPo+SEwRTqqU/Fyl9Rt6BIzba3l5d/fT//hdr2z6JKcFxP0jiiuOoubG7TCp3v48mU1knLW/GxDxcaNi0U5C2Qj/KF80pCPJYL2HcT"
     },
     "output" : {
-      "signature" : "35983027"
+      "signature" : "3153"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "4",
-      "counterData" : "0ztqc2+MGI3X2IBTl3LHvg==",
-      "data" : "0hs1JZK7SPyFKlvITd/ZF+dfwRdBq0NEE4u4CFQAGebPb8O36A2ICbYS49Tn7cEc6+/vWZ8kn6cXJEJBkY+PjAGgABlsUG0QexhVSKz7PmIKbrzmspDTLO/A/VXQyQ/WloxLbnJmTV5EPYOyDcqaye0ec+7xd5L8e24ueH1aTihGS1mKQrn5UAWeZ7aSIkJaSzmJJ1cNikyAIH9vwOsT9kx1lZZ7wndsq7ieUW+o"
+      "counterData" : "wwHmYPybMXuTL/2Hf71ZSg==",
+      "data" : "eoePTnc2vt8cjmW4oFxkg/Mxa1iEYWvXRi9Iz9KIT06ofF9MZb6TrE1o4zkgss1AqFQeWG56NbOKB6VAl34KBZOQ5Ijsoj+/9XXpRF3EOXy4EyCb4y4/icUw14u1PeHQiJFwZuXE8tBzPfwVjTAjnTUPYkCGpYo6ytD+3ZcGcR7vx9OAdk7+Kcm6heM="
     },
     "output" : {
-      "signature" : "32169626"
+      "signature" : "6696"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "4",
-      "counterData" : "ZmBMjIMczcC1tjfNV4co5A==",
-      "data" : "8xeoP/xUPXZXq+DxkT3AC+2oWn818pXHUIiPkFMavSGl2ZEZwrz9jz8s3cieEx7gzGvlDUHP2CgB6OVVzfYFN9JKWmu2DoUasfr6N5CR/TjTZg=="
+      "counterData" : "RggBy14oFoOhxyExIqaAXA==",
+      "data" : "chIHzjQZ0ziGsujoKEbM9ob4lfA9Kfx3UKGWGjeoUxVwuFs67+mejEPolgLGpHti2citkHJwPTNei4A+xtzAr9wOqByxL1KViEadnAxsT+Tp4U41z73p/UbKj17udm/DPjdNizU6fIEyywPQZJpfS80+uMln1Dv4hip8riQdepqoFHahjCw28v1Xhgqyu6gzYTktf78ZSGXFARDckUUKLBE6+v/girbfdBM6hHu57nAkC2SjWItfGdt8zfwtq6n7kjCqwEUuyJIf"
     },
     "output" : {
-      "signature" : "61493435"
+      "signature" : "9253"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "4",
-      "counterData" : "xeviVQM5lIU+qzt55pcB8g==",
-      "data" : "invAmOqEMt1QhHyASGF3CTHaVEWpMHPIzNjmFMTXh0PWbeklRsVmHjGURnOUUG3iflT1WZa/Z29wZnE0k1PxY+Z9W8ItmsBVyvGDejOMV7vMM5M8HCTjWiZlLd8tWX4ndGAMhPBw6vI3GUIMF1YyR5tPpbXFspmY+juWpSMLELISBGNQj63QXiOCEfiFJTEd9qQmaguZQfrL534jOLM8SUXopgYhhh19aYMH3SqE3katoZpV2icDTa07I7DYAAsnnu4CpQCIgq+A7sfD5Oq+kmo="
+      "counterData" : "Y3yo+wo1+pdGzBIE+OG/yA==",
+      "data" : "7WhTKtur1vOERnQzOkkW+J6DYe4cNanBTdjjPvUPKWVGO/F+1UGMo7zJerLlRS72IhlTPgHrt4z7XfxaesJuCAKCfgAlbu6cum6nP+9si3FAR7kysKAFF7pGJTIbAOF0uC+OqwLA6pWCV4faeAXd0QjGztoUUzqZLgiGfHOdGquPyYBMASTugHV/h6FmvdDAX6Z8TQpjNMipudKEWOfxlu9Yi83RIKJaiDrlxBp6J3KhMddYwjDEeErYj1/q6vkD3OZHBiDVT/C48oSgzWhZWQhO7n4CxW9j21/FbNFgrw=="
     },
     "output" : {
-      "signature" : "49225568"
+      "signature" : "6905"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "4",
-      "counterData" : "HsHCiOX8fwwB3bbVMW/rbQ==",
-      "data" : "u0x3zNmsoqp6FQxdAnRXniurRikxfXCPaT25GwcTsgB42IMeq1Fo3WCVbMymJizLIGVCZb2NdtD9VugegOgdM/j5eMj2OASEMdKh13TwDIbV9BKbzVaE7TEO4bEE0yAWvkMjj7dDrioTqXeekXmZiEu+2bFD1toG3/iqrGGz/6TFYNgfu5Ulj6v71vCFGTPtbuQ7IbLaRRi3rVSfNejiyg/JtshdNaMrXeTfGyyP0lf3GMffb+dmc5J7hMJLI8f4NanQTJNffhp4NpUUKsiRVEDvLvRE68JstxmVCkWzjINGz67VQu7+Dd/+"
+      "counterData" : "OyGDeddZPEfjrYEGBM127g==",
+      "data" : "NhEd49rKUQY4+lyrDItTH9PBgAEbpKTIp7aUN6sUfSorK5BI97n27//Fb6mUCtmpqVggKGddnap60kEr2QyWrf96CrVa39R4gdBeXJiQic9oesz2YhYPff2uL8QpBKQ0h8Y6kkd29UIYdde5bKlPYCKCvbZ/xW/CE9UPsFUGPY+UqUSkidw6P8dERB4aehEHrpx+EH4LTypvICuumGWiN4gUztmeVwW81cfQD5se2ffHABXCTDTpkPAUibr+WQxWMCeWeaQOjtQDj7Ma15xvUKc="
     },
     "output" : {
-      "signature" : "92824556"
+      "signature" : "5431"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "4",
-      "counterData" : "bezB6cMeXFOfqykUF36EIQ==",
-      "data" : "Hwg0YJQSqCctKgHfiDe/lVxbrG6tnyEBUlqrM9O7XWjHJhGWmt9O4Ff6r2YvbMRIbAMmmfiukYhYQhMQyNLsIiwvAymHEYP4CHSxxnUBQTaDMogf8QJz/Ni5E5JpBfvSdQr/ZiYAsK80uo03UMNsxsf/sD/GTIl2buQg68kzOJSWATO+xuF4OE3F6bzTF6fXTv53euCm/xFLDupsT2Girbl9scldLZb4ADm6Oei/gItzZoMHpClOg+SHT7YdxBFv3OnlTA7QzKX827893KGQAe+F+TpvBilsMYH0X4LvSzCZv8z6Mm8Ug639DvdOcUg="
+      "counterData" : "Mj08jnvVc0ixHzu1Q0L1xA==",
+      "data" : "74xQzwZTZEnLA3SMyFj2P/pzkZs7Ntzi57JxEtwFTFP9RX7wgW3c7y6QrNbGjcgSB9lf10kSteQ7ervFgACSvR8mFgAX1QifzQwHsbqZdXXTJAd5BVaGFbY1+togUZjM899OLPHcWvF5GRV8FFRsxSkcW/5iJhN2sBJAYFliVJmX1j2F6nuCxhIdYB4DJA75cx+tT2/7O+2ExUgBQeK+/Iw8Rp5HaNIN+794YDwLSvsL1ScVi0ZrrjFRZQ+2jgwVZWbhHuhRsIRFDQO+3l9hPB/9ig=="
     },
     "output" : {
-      "signature" : "52357134-47127856"
+      "signature" : "8798-0042"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "4",
-      "counterData" : "dbNawSWCdnCO4dVJQdY3Dg==",
-      "data" : "4dZZc+gAFeWV+4Uu/jiEYQcP1DOyIE21v8buJU3uh8gxJeQZFbhsV5uHLLGtM0wSlInUSqJeqCSI7QiewMMJAFeljfMf6renAKamRJjM2XwI3GV8ksXdOjaAE9xvpSqWvRbyvAyKXpo6zTKD2qmc1qKO/0h3DOlW8oo/zdiGnhrJ4xyPVcrYhL7Z+nLaOpPbFs3HglYiUGrqkN3oMA=="
+      "counterData" : "YktJ1+Lu3hO/7Clqttdchw==",
+      "data" : "w7brA6Oo3Frshv3EQl8FRKhWe+1Iz7iC0HQA1jmw5w5BbBJ2gR52TXDumpqL/oIip9YoQ1hGzEPzenw9a+vzd9bn9GGWgACr2D9GBAZbWa89jnNr/lemh9lFUrnv3B7tZC2MPuwinh5eJHz85Q9JbOF0xNc="
     },
     "output" : {
-      "signature" : "38432268-44509945"
+      "signature" : "4510-3538"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "4",
-      "counterData" : "PBY+801MQCRhwULZu3Aubw==",
-      "data" : "t9ijub/8NV7MNoDQg2rgmgHZPvVQhPcRk3xNmFZ9ipCmGouAPWzsZzkPGI8KSZ90Q885Jc1AAuwjtDQlRgJStgu4X8fHLHMhOG3k9OD38EwcEUdFxS7e7uDDTB29ENuXsaUFMsMQyoSdJ2zLFYufbDJbMqVGbGOjL5mf0jRIu+8kGxVT2UXda1iwJqXBmUp3m96pTl2iVa0DnoPumaovqNz4gaM9bEtONrRTFiSUIaVQmU87DAhiktExeUl/gAAnbR4wgw=="
+      "counterData" : "6AJezby8fXhfpPQtKKhDMw==",
+      "data" : "cLzgigvZpvjKpbyzsVRKvM7SjfJfXMUdBRsHlF+yCCR76kQy4NC7Uk7c5tEl/616o/0Jq48nHO82agsXLDQ0L4Ww22CIE0EJqdTss7HcUUVdofxDSGrXVdsQ27L1ME7tNshv+7JQmc96"
     },
     "output" : {
-      "signature" : "00508370-70202939"
+      "signature" : "0762-3190"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "4",
-      "counterData" : "1VKmndHKp1iJJ8sXOdZnGg==",
-      "data" : "Lr2RgUAmFo7b4D9wfQ1db4PE1KocXAF6qFxY3c12rHjEo2O1L8PriASDRGkVeWXwuoLqTZfX5joqz8VRTrQ+gh3d"
+      "counterData" : "KBnAtIqFYqJW2EoVedx0BA==",
+      "data" : "r3JF+tzFd1sGi7ApNPzI2CE49NkPcmjBNdHJbaN6TU6c/+muSEpJ9iXtosb3S1RPhx0MFSkbShsZEo5fSABv1tY3RIunQOzRITTLZZgTyjEvQeLWZlvDV5n145+KuVS3NlzhizEEZg=="
     },
     "output" : {
-      "signature" : "40977652-73638923"
+      "signature" : "6066-1319"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "4",
-      "counterData" : "KvKmnU62Jsq5ZBATpuKKlg==",
-      "data" : "V/jie0rZ0RQGz1VkN4CjzUAyKYFUz+KX2tyALk+WIC3hYWcy6zPmvcjbRv8XnYhpIizNIrzhfA3GMeiWOdtNBrgjz6aQ+knmvcPLM59ysFhhBlssESMDncyB93lc6Yols2wIcCPOAwdr5xTXwqc5wGUmxNzYGORFajE4e5AUZ3fDwe6tTUdQggerDBH48fBIOp0q8kvAc4QGvOR43ZIlViGVzJLPxRhndaMe"
-    },
-    "output" : {
-      "signature" : "59868021-67272209"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "4",
-      "counterData" : "M0FubxredE5EbtfUsPItxQ==",
-      "data" : "ZD9u8JUzpOQ4+a+euMeBDl3qWeD2APl563RKPK7QuuTyMa05kIVJ6/RmagWWOPqqHUgnjlZ8tgs0b5yZTr1bAlTDA4WdkaeIUi6eGKkL1Q9om7XV/ib/78VOG9rZdxvlULpvzNrlax/9YBeqe28="
-    },
-    "output" : {
-      "signature" : "94925727-68298700"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "4",
-      "counterData" : "TcBA5nmIVvCmvpb5UZeWuQ==",
-      "data" : "3ZvPcOefvo6iSw73jEU1dnbnXelmAX3f9OOPPv0Qe3n+H4Z6Jbz6IsOT01bciWMSoW08c6Tf9hH6g3q7HKFqC/0TorlRNFzUhuDlEqi/93l8OUwZ08vrkY4sUhajG1WGDx1QLHi86dbTcnokWEbrWSvNN2dJ/cIotcO8gBc+UV0PMJ+SnX/obTU4nk6mFTzyMMGLW1qmTGnIkdmSK92xcCWvwPM+47As3k4vbqYrM/LzpFdPmJc75u/6zPhgaxsHvKs="
-    },
-    "output" : {
-      "signature" : "01984398-47363027"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "4",
-      "counterData" : "dOQZua6MLqheKJFGuBLcxw==",
-      "data" : "BhwO79x+oxm5APXI3mp5Opykk7McSP5QAYJiCceTzqE1w0eGl+YI44mZQ4+d9FVJnFiI7KmehAyWEf0o3fvwE8nSGhd+bgiedKw4EneXQBo="
-    },
-    "output" : {
-      "signature" : "04573250-82107637"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "4",
-      "counterData" : "ut3QtkRKLZEgWBBbCEyk9Q==",
-      "data" : "CvDZMDZW5Cm1sq/9VeoLLds2ZJP6mK+V0NzJsTwW1wfEDdcSCaPt4CWQbXOCsgWAf3exWPSE4/UlWknb7Q4+CCZOApABQ6BY4yr7jyubKAwjp1mnN+YRUHkmiJ/gOkJy/bN4LFsnsD/6jdBlo+qJG0dmRaN5WEcbMaQ04NU="
-    },
-    "output" : {
-      "signature" : "90127296-00422596"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "4",
-      "counterData" : "Dl+UqpVvUuttb6uxe8Yoaw==",
-      "data" : "8Y7X/pOxF/UeepEeqDkJLANBbHo1k+Q5WTEkVjLqyOAPBKJi8BHeduKz57m05v2TncvMyfa3WXrDeadorNUPYjA9h9AfRfiO9EO/ZOH19yPB4yOesUiY4etmfuRA9ZkYakT0CCxS+9Q460QjXghgAeG+xwLrGoEb2MH6PZoS6gfNCtjEuNc779EXXcrqM10xlgj+4T1IHY8JeCiTqi5DFUmX08LbuaqMXlI14tY8DW4OOj7LxJMfqJ1y7YZGcqZ1nzmaWIheCpsWlrHwurxKxKHWgkrePhum1C83ZGRKN37nYYNG+T8bng=="
-    },
-    "output" : {
-      "signature" : "16189781-97354352"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "4",
-      "counterData" : "nmpVfmiejEftx3Mj+8BJqQ==",
-      "data" : "6OGHIGwCjKRPAd1UXg8qodVPSz/TNKp/XpDp1XQUlkxHc1sajoz0peLR3sfditBRcEbUHsPdMd3EXel3dhonFy+xxh641Yd0gZqVX2MHBm+2G1HOPsuS7OiX7IwBpkSzFO5laRd6zQW9UqnLkBAFncqHyVOi9tQQoiXCmvqgCfNAv2/oWaKzIdioKs8="
-    },
-    "output" : {
-      "signature" : "65284338"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "4",
-      "counterData" : "4CGEoXI9/PL3DkIKgblrdg==",
-      "data" : "KFqN7YEquqTVtjeklZQk0aw3JC+KGItQro+MWTgprXJlhqTALbCxI9Q="
-    },
-    "output" : {
-      "signature" : "80257474"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "4",
-      "counterData" : "fc1CyCs5HQnkrLGIJ6CQ7g==",
-      "data" : "ylZGgs0QqvPYnEGyr6Dlehs54HAa+3+0qChyUU0wDuTQ5lb/c8YCUzlCNnunxNuGb1pjupQeShW8ZmLT5+EJTWENAc+isZyYMDByPEfQx6/fVMBvPU3tcnRUI/uyZtGvfcmbTvdL6/GVzXx3k7k0ArFPJLdRawQG16IyicSRCZpSltajFknpsTn0oN9d1mvU/OWEZyUkM+MjOXTAYBziwIb4ag36kFWBqG5iV2oTybWLUoRGOIVjwIDUAjIIm2VPaywvb5D2XuJuGROnX9R96/7Wycen9/j9SrXMnVaaI4pajkqmS451"
-    },
-    "output" : {
-      "signature" : "02710172"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "4",
-      "counterData" : "QIqCdpbzy7zKsuezcexulw==",
-      "data" : "o3vy1CXP5UQuchIAW1HKNGPJaOCrSr9ltee1j2s6ThcOKV+4YTlIev2lPtGnullaDA=="
-    },
-    "output" : {
-      "signature" : "09155706"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "4",
-      "counterData" : "d/V5VnUdGw91UaSHO13Rhw==",
-      "data" : "EYm9U4I2ZAPEHF6DLlpwmsreNFL015BMGZzTN6TCuRTejehhr2KfvxyRQ44zuCR69GnsRYloun1l7Ui/zXBfgNSk/OkvpACVgWlHiUoe4Hjc7i0BNJZR"
-    },
-    "output" : {
-      "signature" : "21500610"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "4",
-      "counterData" : "on87VW9oUgsEl7Z/M92wyA==",
-      "data" : "0gLaGiarIRTpweibGyfn962G7ZQBpZqQj/ccZHcId1K+qYGldo6divefIfJ9xmEBesZ5xl5a1T5mBqGRt+ZqXYxHF9zjwFzq0bf0k4/fOFaL7I3f2soHwgoC2cG2xFe5z5EMOCGFCc/wHH0Pcl4SeDeXkujFl1buvV3mMshWULYEtNZxm+JqZ9r/4woDzIDvMXKMtdI7TaVUALkh4NU8EzEQI78cWW/QJJHE1Q2ZQzAPkGNlzX/7DQNVPAqbVUseow2BT/tuvG4fCSuneGHKI3b0EXHdy7xKCDuKGLISPacKimC6aLc="
-    },
-    "output" : {
-      "signature" : "60150583"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "4",
-      "counterData" : "piWNhsvQHN7tMZWg85gS6g==",
-      "data" : "W0fMrqErOpichAmXH++HC6jOrEoM/S1R6uvftDNGXaVgR8rixRWFhcEPkZO99MW12c+8qglGRpp7KNt+fxjLj9OKnDyDRIGzS80yBjHCt0XO+qIuhnAj65U+ZLWtCM8PEhR7GLMZOT6KDAU3l2gklyvlo8aWBPyxfio/CJ6fy2+DAc+JQmeYP6BeoEwqrNMFfaKMbj9PDrTzy3wQVb0C8j5tx9UWAbSQCj5tWl1izLi4/fpQ1wl18EuwIqvjemzqcSToVz7ByEnEAybiFN/NsANyGVmYHGX7om1deOSd4/vc5zFJj4SN"
-    },
-    "output" : {
-      "signature" : "98606148"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "4",
-      "counterData" : "g9HXiQXG1EY5+Bhkbc5Ndg==",
-      "data" : "ClKeyr+KNarz17FrO3qsQNXRq71S51h8qJ7OC3uFPIyayaszH1SaLdmGiIZi9EG0Em4EjBQV/Rt281WlXuxPLweuxz6QpDphpcloSeDCGFHgDgVoZqYCbEfDt1xXwPlLpnkmsSvlnWDHZ9BKcx1WmkKs8eZ83Y0x/WoNZdu+/iw="
-    },
-    "output" : {
-      "signature" : "62557104"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "4",
-      "counterData" : "gGlJriIGOU9UwC8RNZflfw==",
-      "data" : "baluPEXGKX8ONn9WFg83wJmTmJq9wdmyRyIs/uyO1EhSEP9I7zH9xJxefVF+Acgln+FzUUO6A6h3cyJ5ta82bznxhofijIaj7zShuinSGE1ex12mIRMe5uXawzTI4K4WFnFszOux/vDNmvUcTh9blhEnL25Ml0meqtU5W23Gm4w/1x3H1ghoefUdPzheBtIiigj5qSAZDwgwDktuXwJJRphDloRpfb3skgz9smNyXOoZTD01SJGq"
-    },
-    "output" : {
-      "signature" : "08883643"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "4",
-      "counterData" : "Rq+8mPvTesa8xYk/4JBynw==",
-      "data" : "xsnwOnJ1MJDeaox9D8oMqqsCT/woJ396c/zzQGf6m1jp5DgjdgFt7j/zejei6eWr90Lh7IEr8/eIjuRBu6XwDlf1UFdNnrTvFX4Z5i5vGIef/DBzCOyT05CVcKMIZ6oJXP6JJj6vLlrFnb16Cd8Sz6Z8F2ZuMKBlELjwF3hbtzHd5QeIN+ywQEREjIEZ1tsBuwhKgIA43BHjgnrGZmzKvFM="
-    },
-    "output" : {
-      "signature" : "45756038"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "4",
-      "counterData" : "qtfhdt+rYKiguGkAaCqV3w==",
-      "data" : "Byz9NGVNZnHqsBnVzYlSheLvEyOYrqJPu7vFVcf3+ynJ9Y3JqNLNz0EOImJoKkUsxSXUayO5U9ksYe7gXmdhp+zXvEfQCxFYUbrJswMOFsqmb+JdU84zrw=="
-    },
-    "output" : {
-      "signature" : "97615898-71041969"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "4",
-      "counterData" : "KelKLJ7194gCaRPKI7HChA==",
-      "data" : "0ElfudkcZtzInrPzs1QxfYNVBHpTaRNM2XB15iXHhhEV/OXfTYDxN2NJEXJBanDsi1mKG6h0iGncc48+23FO4vb11C21RfCppYccU25AVNINOuUV"
-    },
-    "output" : {
-      "signature" : "38558255-04303335"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "4",
-      "counterData" : "Ewkk+TYsZsmesV6H3PnIoA==",
-      "data" : "nSh0Wm7LOI6Pt3HOrATqkBlghvDiVcWWTK+DyO031DxIOz6tJYXpCHp9vlGimH22qVJS/koEKtIPfodU4L2pIVgfEnCh8vExjuv+w2RO59hVLjm8d1UnIWSo0ni33lWjiIM7Pl1/VJehHzWlJBg8llTQbdAHqLJbO34HZdmh94O4ZbBeECg8kf7AUPickcUGPq5vwOQcG/VTXXqeqtPKE9s7x/QsoOE2b8xa7AuncXixsMGLwEj5BDTdQVDSbolL"
-    },
-    "output" : {
-      "signature" : "51146469-16773043"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "4",
-      "counterData" : "SZ9Pwv0RrBnyp+zCI5qVBA==",
-      "data" : "ykFToFsOEnXATdiStu3gnllZNiPevpD0sVhJcX6kQDRms6UpC2X0vR6ydMCTPBFV1ITa3danTBMMddLuwQNDVMZgRV/Zcd5OLQIMdt5qYFWDjsarEafcWimz52k6awDlW123BT4="
-    },
-    "output" : {
-      "signature" : "34687343-87001914"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "4",
-      "counterData" : "YayJbd8ftqh5foNlbhdZiw==",
-      "data" : "KGw3CwsdYD9OXOrNJDZawQwItDRqnJh+tE4jhVN5MLS9GwXLCIcRjW++jm1WvHVgQGC2Riu04MMJcKGLWrxOuJFVlwHpD5JcPbEX2OfYQMSMMe0M0BuuCyvIm0KcQZBlTE1ezVsAlA=="
-    },
-    "output" : {
-      "signature" : "18709020-24510053"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "4",
-      "counterData" : "wbWFSXLMj93a/F+3onUsZw==",
-      "data" : "dDfi8HRKs7/1eiOhIiNMyv2CPoYGTNkbQl7Kz8skPLt7tXKBTZYsX+hoXMdOlMym+vMyLAcYHEI7DxsNMyvAduWc9fUkdpj4DbVWqyY="
-    },
-    "output" : {
-      "signature" : "68866448-90780168"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "4",
-      "counterData" : "ThT7bQ7ohNYyqTmqQWkDrg==",
-      "data" : "8NEZiVoOo8CSDkBaN4BM6/V9Cn6TgvKzGK2/8eTqETBEcXyTCwQSCreFB/I5xV3OxsUPyZ2lERmwRt2q5ZcWV7c4Yj+ruFUSh6ab7sodG+YKXu8ullVgUWaYjY5RIuTH13IQTsILKketvysmV69bQu0gg0a0tT+/vfjEcbcSlC4N8S08BgklHN5YFhLY4SCZIUH861//cM57uoSjjHbjojD1yiHGApMyrJcf4FkX45a/xPdJ/+8fXjF02yAM3FMkQX0cLq45am3JuoWGep4pbAC1PInvuQ+jP4x1vUTyC8fw3WukZAY="
-    },
-    "output" : {
-      "signature" : "05367873-03223065"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "4",
-      "counterData" : "TUVQJjZI9SWuOzHgvgEctg==",
-      "data" : "qouVn0GbVPijwIQbW+hdDZx0pqe9tYAguAk3wlxHv+mPBjd9ePAJHnV9R5FiET1qI+qHf/WRmqV/HIdzVaddU2LCyOttSWQSYhxabfRd71fYtvBjUfvw6dtsEJpcscuSvPG2uK0fwR4Ne2eaSDd8N8rHbxxQjmEK54HReXYQxUBjH06Od6N2U82p4A287YjQzyTEml7HlxB/DQd2JUhuPGcmBk5g4UgN"
-    },
-    "output" : {
-      "signature" : "96396865-44980260"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "4",
-      "counterData" : "iC/6hkfZjPTsbdQj3ecRpQ==",
-      "data" : "7Hkh0JnMENcLvVQZUN1biFNqhucimNB+peP6DB1zZUcRTElhD8BpQo1xEg0yWQq//T6c/3qkBZ57FwjsgBohIleWUKoFGZF6KmnDM+bu18Cot+rYINOmi96dSFs+LUlWoJfBIHsX+Ns56clkrKRVzZi9UHhDQ1PunZWs8xzY"
-    },
-    "output" : {
-      "signature" : "32105639-10684699"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "cyEpSx996CW0P4GVOz0V2Q==",
-      "signatureKnowledgeKey" : "MWe4MLCmc+DZY0poMBhjsA==",
-      "signatureBiometryKey" : "02Hqg0pCO+KWdO6QCRCUBA==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "4",
-      "counterData" : "EBgYoBmjWhN2zTlrmtxYHw==",
-      "data" : "smNqkJM189uEDMkF+JOsrAYCGHZ3s/GYmW61Il/LRXPTW/D3/Bm3HvddLbAOJpHEljZO6Tdv3jKsZU9nIQ=="
-    },
-    "output" : {
-      "signature" : "93956166-21088792"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "sIwXmMaMYEYSCS+mmkmYPg==",
-      "data" : "yj3z/Rhi/RLdBAjV6ZlYdz8KBQiInuMCHZ8lyoWhfiYCtJrWtIJyh3ByL7jPFqof8J5INNC1KKzr1HyeGgBfi/QRMEnl"
-    },
-    "output" : {
-      "signature" : "52808060"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "gS/tAtUtogr5TXeER3dwgA==",
-      "data" : "LIuWx+2FVhU7J1cAu2SkRvXnrYlINfu+gIdBzHaKa/OAyjTFpGY/hM1XtHQsL3MhHIJ4FnVcLUVqELb96NrXZI7AIBsePsJxf11ti1GEtrnD"
-    },
-    "output" : {
-      "signature" : "90902616"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "DLxwVzHHhLBF8QZMqv4MyQ==",
-      "data" : "ZNQECu3gTiLe0X89n4TmMVzbnpYPYvnNCKzMX8Rbjdh61A2aovjC3kKYm7ynhM4Xi4Z+LTn5BOxlMmyLtPT3cQ+97Qf5sVaQEFLLDHUrGz8czIOse6QcPKW6Mtu++neIeWX38KaYnHKKetk+z1bNrnkxke2+58pnpNx4SS3ofMg3zfQh7xc1Db4dLLWnQhIySQ59uZO4P6ffqiGUfnuMeO6m25K06t4ApsoCUuGs4sH+9G2UiiBK"
-    },
-    "output" : {
-      "signature" : "78671768"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "9z9nPur0PgrbD5JCAr93uQ==",
-      "data" : "Tckjwuz0x/hX24HB4tWDDowz3yU+Jx8xpwBJBOnftovB1aQbZ4PsVXR9WpdL6j3W9wWRjtGAHSMGgVXNQdPudQsPm3q+9ME9+e5NTuKu1Y1+e5UR7kpuE4MkR2DeoWj8wqKsvjmJrzFQ4QodOY3qtEqHYpVhtOCQeHQP+6em4p3UUZ8C7KiIWYAGEZNUFiTCUKngYBYnDYZS5rIpK8c0eI7Ohrvv5id2k9nNcOrVUVRDsr/qGPX5r5cDEkza0oQk9Qmn0KYJn3N6tjoCuegMVGK5A+jXJWzzp0Jhe6hsupMR/fxfEN+LfyeAktftF007TwjkfjtZYsMXKujK"
-    },
-    "output" : {
-      "signature" : "72499299"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "0YCdrTD/++R2yaMM0bgnkw==",
-      "data" : "D9ZRBHOkCEcDlaL1AVKdDFzzBxZj3Fg84evH3eC17UzHALBdun0byEIVNkdAoStYKlBCdBnZHXhe3GoFiW3HmFv1QIAIDQAg6dRqnbUZ66xX7omRfLUcvObu4IYWtB5yIq61PJszL1/FbfMiHzEVFKV/HR6mFIaAaKvJqzS8pno="
-    },
-    "output" : {
-      "signature" : "67337188"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "NICWGa59lbjm9MyU1DFkOw==",
-      "data" : "baKovUsSLjD0O/rL0JCqch8k"
-    },
-    "output" : {
-      "signature" : "88001553"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "K2yMX1uFovGRpSwBqQsvbg==",
-      "data" : "Tx4kbJuSHAS3OQWXKrHFsrSzUdOTsEWDzuffQerAQE1xx9Uw7K6Gh8r2m0RxGu03H2MTbKqNJwff25YKiWqKYupTCV9GBpaxgIXcUWAbMBUqJAScvNILnquuXOIMAQ9gGkzW/uycmd0Ojw=="
-    },
-    "output" : {
-      "signature" : "88453785"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "Z7A8S3VhavciaH4U2MBDsw==",
-      "data" : "nag+jQUljfCC5S+MiiSq1ZtKRANv+sTHGNkJ8mCEEnC6xiYcIikd8c9UMzgyGHvmkWCJk9wvths9rSza5ScafrWd4XRnF7nt"
-    },
-    "output" : {
-      "signature" : "30160317"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "U1W7mazBSvJumzRfQzqn3w==",
-      "data" : "gdk="
-    },
-    "output" : {
-      "signature" : "93499422"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "ZolHbufVW1rhhYhUoP5+uw==",
-      "data" : "jQHygDoDXskJaNgFQlHho8TGaoUgC4YzDgVWvhumGxCOMTvPPm4C8yjFwxbeA2+LsJ59ntxxfTQKPR3qScCX3GKKUkCyUsLnDo1dMTq06wHVBVRQBFgjKH5NNfvvt1xeLHMdlQUjH6mUP8TwIqmLdTTMa9adXx9cSqGhacvkKtVx3Ob79UojuTMZNhjJjsgVq5gcLZyFr3iNJ8o/E4sBgEiOwoQKQJo3YwGpQjwsMsOaF3sJBcAs1tDtsoJ0W762+eLEJXj+kkxfJZewv97GsfFcOJxj3HAPpCcl8HYv0ALNJf38hSVk4RunaZWJt5Aj"
-    },
-    "output" : {
-      "signature" : "55569276"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "cMvaxH5SxtkXQhPAl4vtmQ==",
-      "data" : "D6RvzJU03X+HSuQi4sk1/5AZ35PeUF9XHAOIiYIzCDCq4B4/5Hd9Gjbj6DXy3L0Q1eGqTwAdUbKBiJZFIO2Oaw5W/Sqa1Pf6V3yk3Y3bWQBsJmodTZEQXrnVtYfAQSQ="
-    },
-    "output" : {
-      "signature" : "88532479-33882396"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "sQ/lE5Iwtm/HH/CDivh36A==",
-      "data" : "7bI9Zd3B6YQ5KWPwtnmmNgDoIfUWXSUEEaPQF0i3Fg4Ed4tb5xA9TSJrAjhoFux4E3dfVBFNaYdjpQAWLEYGeyZ+8dovy9J8UlQ76L+uAilfD/aSFRMakVdmmhpQzSK5Y+hc08DRMTaqsZ5k3Pj4NQVNj0wBsnHCa5N627A8bM2wuE0NeGEqMZx5B4VU+Xuuxh5dPcrUVWiLU8//EviIIsVj7fJu7WiQUlZ/J5Vm2LvZ08ssTq2OOToxTkqVhXen5HJXQMdpndmFUMAqfrWzPRvRQ+v4hYKF"
-    },
-    "output" : {
-      "signature" : "19536520-77971993"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "akg6IhO2UbivPZ0C+gDwJg==",
-      "data" : "lWHoOGW8dhMO6g/I5foDW4Nk4DSgn2LXibkybJjULI8vApPuvyMZ7PQo"
-    },
-    "output" : {
-      "signature" : "64152119-25339552"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "h7QsdbkwGtfZElTIELmmYg==",
-      "data" : "GQVBpwdc9MKLdkukr2RbTosy/N5PcHyGxHFmnvgWcBihj+a8SYlHeQERx3U1xx2ciUkPCUFy4qj8b+EHmuLeHmvfFUC/8zaBJTJDpzbD/zzJUeJ/QJgg7FOJHUso6Cx1JiL+OTDkookBaAIhYI5NJsEcytPujkjBwgdl/5rhoEyQEWGFcvGNuIKahN17N3QDrGA="
-    },
-    "output" : {
-      "signature" : "51183891-48052741"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "Ir2nqNWulRWGKRtLa+c3Tw==",
-      "data" : "COFfCG68MSs1Pfn0ubU3G85UCsS5lcpj7DZd9sJKOHJd0r/vOzOEct3/R0Qq0j/r7cPK1LjNJn1PtCefmnGBTFG0/xoaG89/E1YFLk3sqSNbuaNwY5MassY9y4i7TKzBZ/p4gZ3qL+q5Z8sr8l3aE5VhBplhcfEn8aYRQs3cC+lJ7C6UeRONMyK9+cgZ6KvK7zOOJqL6OIRzJlaEav5Bt6pSxamwktk4bNMH9cuKPV/zd3IdOj92l7qAm1Atbqb0ZY60Ubdzos0mJgjwKik1gYzZHs18rr2h67Vx8/5N1S8AIaQPymdSr0czwgByLgpREhc9pl6Ueg=="
-    },
-    "output" : {
-      "signature" : "08119190-01151809"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "Oxr1Qyohu9y7evlaHrKhMA==",
-      "data" : "6RwmIB+P/qGOoY6FWhDg10MiLfmLt/HAWf5hdJilBvFjITzlmIFoHLi7SpWqKhmcOrfNmJ/aMV4p6KY69U6sYKu0HjLdL8uYFKm1XOVTGc/FgWrr0kC2EVAa93zuNSEFa1DhURvxH7qTeQ=="
-    },
-    "output" : {
-      "signature" : "05226367-72183549"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "Z5hg/owowyx75yrjhOhQ6w==",
-      "data" : "4RoAyLyoI8Uw0lrL9dlu7FSSuVVDbNK2Un+yQ7nTNbpNp3Y1MySVw5aEZ0kTBnTMa0jfIWnUjkrKFLZcBhMSldtahiAyf+c+qO4fsCUL5iI1VOoNDwL7jtyQBKzJ68+5FWyINLCyp5Xzs06zxub6+e5fQAJU4uTK62zu0HoPEOAyzZC8JdfBkIpO7ETfswfhRhPPVE8eGZZaIfqUaRqh6L0LaOS1eLLGdSdGeXAcvgbSKZgeFki40f4dyuqYIHl+aPm8Et6DR7i8h2L6DfgFGWiHnkvI"
-    },
-    "output" : {
-      "signature" : "86616481-82346338"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "3lpaI83Qaf5D/TnW+W845g==",
-      "data" : "loIMTgYGwlZXC+oMdbRomixxvAZEsVYAF8R4y/4hhsInI+943kxNrC7HnV7UJ3QkIOd1+q2jK6lh6WYEFBrVVeQtGb3SR2vT2Gmtu+qq++PLOWqm824v11O1r95RLK6zPENOoNswmWYsJEHT27tzlBrejSjF5MbTaq2AoohR2zCTSHYXnHGjY2e5yFEn45ZnzWJaI8w9ylSS2ba0hESIsaxTgUIdwsvMNz2YrZ+fku3qh4Ohyw/NpadATY1WfsFf9gR+V621M+4R9fZAbR7u"
-    },
-    "output" : {
-      "signature" : "85621027-41044345"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "WqfBnRIoxZwAWCvtrnRarw==",
-      "data" : "+jLvvToe83OSJr43rvtCn9s0uPI2lWmgzvWmrUp73WXvgTWmHNNMR6fwSInokpiln5Uv+xWr8/6yFzNyG30kDPJIJl9c7lPHL/vnNj6BuuazKZqW2vs/u94RpIkaMJoKRhVGENJfArex8Zpa1rXjb1GZoWJo43/e8mzsZSkP9JAmpcVrd7oEUdaNPWP2fUGEcuH+5WE8NWiLdCgBZa3tZce30ec2zcTzBtZWA5lleB+ZoEODUmHcmROHFeE+MdOZy6AX79TnVi93tEAItFS2drI0KcAehSgUtsrYqAXRn91+YhBzGsztLf31rZcVqLAy"
-    },
-    "output" : {
-      "signature" : "16867429-79419749"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "IQBszRDSePwT5fayLpp7mw==",
-      "data" : "uNzBi5/uyzIlu9ELVwEudHYcyo4N1wrRqQ=="
-    },
-    "output" : {
-      "signature" : "65101081-03370319"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "hzjSx9DXkAnO0+EG/CaXZQ==",
-      "data" : "6otEofLwTiObyli/2gBsKW1JsZMPiPDcZ3Pk5k0hjtAdtbisVHkldXoG/MFG/n8eG/Bf+TY4hxFJSFB3DaKjA2qRUcRjPsiRXHwwDtsfotkScAAFfBQrmPA0zDPJg7UsKC4dqmzbDJhMQduQ705ywBy4ozRn4xrAIHPzNXTcQBsKcY0vZc9qwlAWKbGj3K6qmwijLOrpQ8fBhGFHsdrhg3/Ja4AcYxFm27Z5g1UyANiB9fKpuzDLi/G40/dv+pcQTw/tlcfzLsVqFvcCV9E0tFVHVvTg7w=="
-    },
-    "output" : {
-      "signature" : "52659199"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "cWPsgqUX5V0xPT1RQImpyQ==",
-      "data" : "9ey0shZBsA3mfYPp1kuVUF4FYtVBU/1S5egGJo7lTh6ElWRXVtCwSEcBNx4FICnIAMRYEVtdS31e/rfchVT7evpK/g6Nb4xC7UlTCd8FT0c/SA2bvi5jcE8="
-    },
-    "output" : {
-      "signature" : "24721008"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "ofiQupeTdXJotcHALhwQGQ==",
-      "data" : "cdJDsOARMTeEhPH9iOJjqtGYpO+ihADoTTPUAIHldFCPJgQOQvgbjCOdARQj10Nh0W4FvSwHEbA0/r2G4jz9MbGIEohMFttKEKXSn5E4mAroD+9O/ZOtfBnX+pb1BFqFGS4Tqn6z9UxmtKpVVhbU1HYXBGIoRPkLh6czsg=="
-    },
-    "output" : {
-      "signature" : "03504829"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "O2uOaCzmthD3wRgAOgAQRA==",
-      "data" : "lIwmM7CmKFYwzBkYu3Yrfhf97r9+SV9z7BlmA7JWYEmPaT4yfmY+UfWH2cWk1u90XaO936QqUvY9CB0EEa5ay6c0qVK8dmQ4xqsHFnrdyz5TWOXRnqdxcPsbCA6rhB87I2Qv8BN9hUbONtB/8OA5QcfF+fumgJ6KnI4vT8p3rc1Bex4r82Vaqm6v6XfLPjFaxcaNeqloRLA6NYZA7PmKvfVsLM66+pmPYp0HJTQKyC3EhoPCKockxgSRlydw8ebNlhaXb5GtWx1jigupDAVTKfZfOwWrv1A="
-    },
-    "output" : {
-      "signature" : "97673444"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "P4KyW1CzsTxs69KYL+Rr6w==",
-      "data" : "ylcVnavmZIHa32n7T/8rCUwXjgpE"
-    },
-    "output" : {
-      "signature" : "77021011"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "MLqCNBfcoTf3N9Lo1b6cXA==",
-      "data" : "sNLhJvWlVcpOBKVE/igwX+31PGD0z5ClPuUfjBnnXJtUiRdNe9Xk6sWsfYk9tXycKCExhWOBF/8uOeHygJbm/TZNcfj2I/Q/xZnICM14wW4="
-    },
-    "output" : {
-      "signature" : "27325916"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "tBSLRFqYhqd2vVd8XKToRQ==",
-      "data" : "ezXHzwHm"
-    },
-    "output" : {
-      "signature" : "58003108"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "MWziuUoOtr0i/YPWxNMD9w==",
-      "data" : "ZhBEW0lFH1VqdBLISE1bZLmPUUSLMMsldUVnS5BB8zt/rYi8BDeYQw=="
-    },
-    "output" : {
-      "signature" : "49716842"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "iMScP++c2bkM46IL1kohfQ==",
-      "data" : "CbO1tgWd+oNQ6xIw4fMvHseuL5q5K7Ho9jKLH3ymTXzm+9oJ+z0xja/+COSJ27QRxLkoWD3OUPEenRk89v0wpE59MNl+ZGOrH8DWSntBrNYHB9w3LMO6OukLICxvDh9IEyGjghQJ0R0xce9VOoU2aPZ4tN8hD7M6SPeApWQ/RuAf284MtsGj5YjS5qw="
-    },
-    "output" : {
-      "signature" : "22909434"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "5",
-      "counterData" : "aBlK2/rtrvrYZt8sd7gM6A==",
-      "data" : "znwdGdZWJl9a8oN1MGPXDm+XbJSo1UxZcWQq8YUlr2O8O6sajG10i1GhLHQTg93R2ZW3fxrj8L9BDcwINseZOjNttLoJo8JZ1I0zH+focQiXjCuIdnbc7aDsjMxBlgAbI2k6QlLKNe34tMZm0L0+gpD8+7+M8pJYN8G+11WajsKz22Hi"
-    },
-    "output" : {
-      "signature" : "20855465"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "15wryOh7E7Ywve01jqUsYw==",
-      "data" : "VmznHh8aKPTu+9EFCTX0FK93siw70xO1heWPKIQnrQ6nUFCvQQeBq6EaRVyz1txb4AgeoE49KQTPvlc3oCEGNZbX3DbmpmXAgd/f9IMC0fdsyTpfK28pYik6ftFeLxpyrw=="
-    },
-    "output" : {
-      "signature" : "86318068-28917634"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "ZZ/d1apYV0CQSahVClauqQ==",
-      "data" : "8bJ5J9dDJYl9fZ28QKcbxPaNoyT/0ltGxJ70QIkvwsgCBO0pEJiXEc2KOgecpzQha6xaqvshuw83xm+7pqsk/ar/d+9A0HN6pgZBIv1M1qvY98oTaW9D2+WedxjrAbQ8IH7ObPmejbWtaNjTZSjxfzzCbvuC4xHywp2SRTvwQGNntfpeIse5pz4zwD9qB6K3ZJJEHBeMXkE/XI5wFElkpv24NKrK2gei2P/otaQWd4YrEDhg7/So3tE="
-    },
-    "output" : {
-      "signature" : "64021084-96386320"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "nVXa39OKxdsAeRPul1yvvg==",
-      "data" : "AVTSC93zaNtceNbO+tqJg5PWirJacM5vL8XjI4cXfTq4MXvx55JbHeG+GmomL1KNFrps6V3eR0eq7vHT+hA3U5DVrcnbVelalIyPJZgImS43MHV4fHUMgcOeTNgc4JTP01sLs6eXAqzW8uy+EfGgC+KclMObhb92mqUT6u2DqHA2odhRa7CothwIVzFj2WsWwSzosr7kXkCTsl8SgcSRVvJE9GU4uvBb4GPD7fSMYYu7t1A7vypyJNYnlPjPYjTLApeIUsjY"
-    },
-    "output" : {
-      "signature" : "96979848-77880752"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "DaD1ynoyUrTeuDRlMuWlJA==",
-      "data" : "R47dPBqyCM/pl9D48sCPYgNFIg=="
-    },
-    "output" : {
-      "signature" : "62706672-67061688"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "6yM7igV06nUHXC73QwLy7A==",
-      "data" : "w/Yp1lEA91CEWGQMriaoIWQ6/0QHlYKpEic="
-    },
-    "output" : {
-      "signature" : "47860791-82493413"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "bCvPmvjNgcRAxvoS0HJb8A==",
-      "data" : "4hk2vA0/GX/MmB90qGHtvuL0ZR/XP8lH6mtgUTUWRnCPB8JU4mrD7f3sXELhUGvxygxLs9c63PgbUiQfCm8vCCrtcLfDxZ63Zqv7ak/9PyRQBuHjROfM"
-    },
-    "output" : {
-      "signature" : "59501504-51781827"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "dmqDwguJbekLWFB2pkShLA==",
-      "data" : "JIKo+ftEEyYpA4gzA8ObU067XqF2D5ftqg/Oy2m3d263NCDQ8teLkC58514/0LHCsr5X1WQdipN6erpypWXeiVLbNJGuTawV5hwPYzkPYw=="
-    },
-    "output" : {
-      "signature" : "70085126-76855344"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "6H59LqJFD+DQWY1ivOTyaQ==",
-      "data" : "CyLHQEqpG6uXUHDj3E1OXrRcIFvI+PKsV4dUkOKFWP8U0di8/6y6b5cTesWeiYNg1WU3Kp9u5DsWK9m9AL+V/HqLCmK5ikRKIa6pGm1xsWDEVw24ibxB9E0751JD7wlh16V7m1pW9OzJTtyTJEDNh/ARpgInJOY+Q5vvhMByLvE1g744XonvSYweH0LAFEMP0ETytkMzgThryRR0lm3LY6Pf8+OiHoc2N55YnfpZg3MlyPpdYActF5utNSiasP//GONrMtl6Vw=="
-    },
-    "output" : {
-      "signature" : "89839209-51058987"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "wPwRDbyzvaYFWn3FEC7/8w==",
-      "data" : "5YPP5w4/5dbZHw+3MBYpRx8n0AXPSSjwxRUfo6/rKb+oJekO13E++q96Krli2DMxv+eIULCKpaUUq4XxO38M3Uaxk0PmRyo="
-    },
-    "output" : {
-      "signature" : "37217890-57268958"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "dlTc1CHZPNWQq6+1KpaN6Q==",
-      "signatureKnowledgeKey" : "qLNHBBqgkIM6Y5fdtKikzA==",
-      "signatureBiometryKey" : "47+wO9dB+umAhRXH5+cKZw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "5",
-      "counterData" : "TS7kp8PfmIF1wg298lXmtw==",
-      "data" : "y2zKpNO7xSEZvODl6BsxjtTmiPkjx81oi4FK+ijlra7jQgID2euSoPbyYQn1xQ=="
-    },
-    "output" : {
-      "signature" : "47248945-20939013"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "u35CkvqoFecMHzCAZZ9IIQ==",
-      "data" : "4pkcn3OT6d93GQLYEuzW+I3Cil4LeYkn9dbp3nknAW2CXo8vd19Uz4szBJTsrEdrWnblRlzMd2OKPZ2u8wnBvRg+J+vJfUqMzkoeF70wK/5s4pV/ETPCaj8="
-    },
-    "output" : {
-      "signature" : "15377547"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "eHA3U+i0oJSkP5jAGHPiKQ==",
-      "data" : "THlP21u6ROVLvJ4rhKAj0EL1NJ9xfwJU6Uv/ZUf+xXkMhiPf7IdmqNa+ACOSvNFKj+xgTAOuM0nhB8o8H/b5Ww1EN5iGhCaoqIUufg=="
-    },
-    "output" : {
-      "signature" : "25439855"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "jcQ3dpg1m9a7EcEXfa3jKw==",
-      "data" : "IZNBX7oiiPlGYoCCGU0UEKSWzEV//UbyKTgi7QZaYdW9U1TjXm3E68wb1hKr6omhw9RGSdjDiXuAIjaymKlnx8EWTZZl2HW/qCxCCpaz9G0fWFceeYDVdApfeBTSelR/b8gi8ZcZE/Ho0gyCVWGVOBY2+5HbXpld+BVjaZSqBPFXCgqeDS10"
-    },
-    "output" : {
-      "signature" : "80869955"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "KCtqZI17vStbW8CWxYgA0Q==",
-      "data" : "fQ59L53besQxvwJl1ck+1Sehna6OZ72mhyiZvAmWWFtnNuor/PrIXYkKxHPKuQyCZ8nkNYKycJR+UnbMpcrxmEf9cWZuJuoY90rrD6ImSkjpD1w+RMkgVoFoscoC/SibSyeS+5rC04yXZpDEIfx5qG5kVUMUwOhwoqQttELwSB58CvfthAfmAN0/Q2UdBA6NRe8Y7wbgskZO0JLHqfnkOAdHKYExSxueElFPYpnZlhn7TfHFij+BVwo/fO5INH+a3xu8HDMdyOHGEOawHveO0Nphce7XtX8UnV7i8UOTY3OcrwK4NgMOoCJEFOp182uEeabBUcs/evM6KRD2xNw="
-    },
-    "output" : {
-      "signature" : "24232722"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "BSbPXhoGu5HB9vz2bV0x+g==",
-      "data" : "Q3ctLsh7VzzandlYYDjXYLAZkX6dUD+bJAjZqARtcfVf2NaWHzD+GpPWQsNfaPFgWq6B9UOu548oOVhMgs8JrmuXHRji7XuPEt6jVAlfE02a0d3iMkz+mSG+4GbqX9LKfK03y0l53GSeSlZBJN9HzGTYAMcD1qDP+5yHFXVMf8zWLW2bYSNKdpfhwkM6hxXdYFg5khSgNtiN5jv0f/xhQ0jjXsyHeT0upTlEqoTFnp0fdHCDCKgW7hCLrXMUenHWv9w8Gdopl5n0"
-    },
-    "output" : {
-      "signature" : "70040214"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "5UdLZk98bwruxYf6f4utJw==",
-      "data" : "L591v4oiNvNovezK8QpYTZraA3M6dLqCSs54RkOGfnywSm2ebGiohHglj/BtXUfcvq8DVV4hlF/mckak2nIjuznZeV2Xx5x3Ulu9LAaVe4lmWQwO1tFtQpJdmUZL/6cDH5A1Y0d+AxL/Icb7WzEsmV1cJeiGDNYpy9OcYf9zfoXgv7kcBV40r0uSyffXXpWdV8kJcz+RMsm3kQo6UolmHPPmI0f4p3v/+2A46Zt7ZuDbxcyw8jBATr/o+9uf93PZfQw1zzzoV9t/gBYcVHkSWemrVph2N5WrdqVe5XBLMjJ0MB2CAM8ENO2VLog+YwBDkAZAAk20XPO5NRc="
-    },
-    "output" : {
-      "signature" : "17328390"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "ZhYc+zE/DnOkxWxGJPFOAA==",
-      "data" : "p0AaiRBDhu8uarjJvZXaH16Sj9UuCwv/kZIGyaiCYvl+LVlhfEzW2KUXAor4T1n5VainhoV9nH1PuaqgzimlP5r3bx2KEsCgiFO+w5tcX3UDSfhUICLgxiuGvqVXp9Tvkpy6hoPT3jIXAxYOrZyBdc6q2ym8Bf8Wg0+DnOpIfWvVPZn7Cxe1WppKQGekD8Nbmat8QoH3z9TSEvMBV99UiyzCSKL1Fh6fv+nG5gs8LyyWWUxYZRaOKsZd7u996Al3N+ezywxqJP4ozCdXcD0="
-    },
-    "output" : {
-      "signature" : "27621254"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "u/2g3h3QYhABgVbdgekFXA==",
-      "data" : "n139Jw=="
-    },
-    "output" : {
-      "signature" : "56148925"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "MmdmFNnJVF3kPEKNvhQgXA==",
-      "data" : "caIn9KM78QAdMR5udOheGILCx5s71pvfPUsYcgRomvElWCcXdqDtrqwx4+S8iShgeVHFHXa97PWUpfPW"
-    },
-    "output" : {
-      "signature" : "17906241"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "C9Ly2vqNWDH67bP4BkxXVg==",
-      "data" : "5ZrA4+OuEURPQqEcuQrNc2GZw8fjh/1UMrdXXPz8sZoebZHuSmauaeH8HSNNnZ5cyEgTLue6eB9lKbOAVUYee2aSU0O2XBKX"
-    },
-    "output" : {
-      "signature" : "03557174"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "i3sIC5qeyYkILbucR8j28A==",
-      "data" : "kk4lyDvI8bUZnyr/+JeXSrcAABtEIE+sgcNLYcg69DT3vPHVAcoNIA8NbZ3r9xAGb9fsowhTitzk4t8aCY0p4yAI1AGYBiaoYfDoAGUMnvVO"
-    },
-    "output" : {
-      "signature" : "45149017-84052624"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "XbcgV4qbDg95K9bxqRQJog==",
-      "data" : "VVXGMO3ZUPRMxgsYkcrJ"
-    },
-    "output" : {
-      "signature" : "07261657-72249725"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "2bp1bhGxLN2kX869A/IkLg==",
-      "data" : "vibAa8Sd6ZyaGrTjPZe+OSyDLbFXbA1BHnuHxnfiHBlcHmN5gEO03sEMM0JT5dF8JwtkYtncELQkM+TASqyF90m/CfaHqisBqi6YBZxgckzh+AhUVobooL5igTdVpZvK70keljz70VGtz5R1o+SblwFmJfPwLYdChWjhY+tUJfId4KiRG8kYEUzn8s3BsJNwEZ2l4ospI5KRR4aCBxGK"
-    },
-    "output" : {
-      "signature" : "86715424-23672269"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "rhDjsW/CfQNWpUHonXWPJA==",
-      "data" : "a4vzCRcWtpq/5P7E1/Q3VwlAKisDDts5ApUMlK9eQnyG76p2W6KMO02PmR2pyZvwHTJ7HIe9js7rWT3/iv+/W3KRs0ecnEm1Et6pORQh7/luURrAJinFVoVJln1VTg12+KjjiJy5aQhPx+JvzbvMliYez7pNC2BBw5u6EjQYifMhkiARAepG"
-    },
-    "output" : {
-      "signature" : "69495832-67761168"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "IziNJpnt2S59EzuTPqi62g==",
-      "data" : "RAxj+7b/wruRTn1wWvM="
-    },
-    "output" : {
-      "signature" : "69421839-80919610"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "as0KGyBn0EqagybfDyCsDQ==",
-      "data" : "q6mQnlIcRUap2QqMUCuNV+TAgTnoRJ/7mFGYQHWL4CmfQCkQKlh5UN+jhnrzICHqXHw0TUI1h4lSL2d/EpQoaXYlHKQ4jdgtPtfK3grl3zrwl5HtcpFhh2Pd5/X4XCh6ODEZYn9c/hwiBI30hxeLukNzwPwWxKDgXaFO6d4SykKugQ86kEFroOpGjTzPopfFENHBme2zwcxK/tjv6LrJMQahxRRS7niH4NFUEeTmBnrHW8tHpv9pVNGHqCm7wzaOt5aB0RbX0/6APifkyESy4MnhGWkccbj8viWV7/vfB/Nact8DIfvMFmYVEC/EJQQbDUxbMLxNf6g7OnZhwt0="
-    },
-    "output" : {
-      "signature" : "43193995-40518459"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "y13ipAN3S+uXsGZoK85ubA==",
-      "data" : "vgqiWFcn6xOqTGegyBu9hlpUeirQY+MSbXmz0GGAQbPMaw+6D8q+R9vc/s3yS5jBpWB6VhEGx148QxAouHlwjcm7lInLbWeS/jGwgTxIVWGwWA1yeFdfgTwHBOmss9hdunRMNukYHi/bm/39gKGBjaBReR2hoMW8UMKjeDErhI0Z7yqwXLoh64FWKc531G5pegWZoapPm8mOZPRVMiAKCgA2+WOe+YwcyLx9mkiaflAKNDkWhRZgcSfvseVv"
-    },
-    "output" : {
-      "signature" : "18803470-14834413"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "R9ypwOWsRKbP84aXWM1h/w==",
-      "data" : "KVcqp4IlR2u8cNbYqHzLWQkieeOd82BpcmnggydPdWLF4GQZL2HmjYlyS+b5QA7Z8FB79Cx9PKiMv/lTyLe2gLdaoBBumQHbyBjMVNTCjtBT6kkAmm2KkGT1PWmLGryfLZ4Sd8hLNJ0MLiyCQ556Q5IUWWApUx8cX+OyAFPtxC5uu7FiWanjGPXiAb0LWiR1eeQazwn2tr0IXcChle8u3TTHDe05qOegfFn9i8rvx8A2kX/zV8O7WEkz18Nq"
-    },
-    "output" : {
-      "signature" : "16796250-33991454"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "ZraOJS5eH3aY6JG8GaDZjw==",
-      "data" : "olr1yDGMNzwt4oa0ySGQqOMFvz++UhaQVJZB28qsQ5IsESpti4Tuk9lrHiTSmRxZD6APi0GyBcDkRYN/yW3K8A+dKIGxgUZMbtVm+dq19IZ3s+6zPk4ir6pforxQ97tH7+cypji0uV66N8NMCSMNTbltL93LXnRVtg=="
-    },
-    "output" : {
-      "signature" : "20606821-43004202"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "Fw3BKdpUUqKfM5xicor9Og==",
-      "data" : "HaxlNoLpBbIoKJFTJAbg/CyuRenCdKe8whyFChVVzsciYGK99MojctBkk8hL8+B7KC91s2dMU6vssYw2uk5fQorotLy+nwAoV2D/xTN5vOnDgPC6PE2cfvtjBDf1nMU54DKc1Dd5JPbrgmS5QdPPgskHEIlfzOr+shF0TuWjga/bhpOvHg=="
-    },
-    "output" : {
-      "signature" : "34726385-37164512"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "dH0veYjAKE8TgXhRAr3cTQ==",
-      "data" : "ykHxc/dSdCYZQjwMUYRpa/GHIdgE9GUeI6+qtz4Iw2eGrqRpKtY/i0wb+UE5nct7hCg3KAdPuBAG96YhKOSGR9F8M/jg5WqaTc6wkDAc7/91Ed4ha0Z7P+mAinbLghN1refCfBVemq8AKCzLdfDq0RNCRuVvo66ge5DJNQrL2PFG47He6NsDST8qwVpEOrux"
-    },
-    "output" : {
-      "signature" : "21458714"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "pjtE+ISnXUM30tLAQPBuGw==",
-      "data" : "+S8Mfd4guIQy41bXQDOXkb2HIX0B74000oqc8G1VnmKDBvMXM6xrjpf2xp9HYR1VvJ1D7rNpAU1Xdm/DhoOZpCIAMjFQMUHMVtHpeW679bWP45kQZD7TntZez4T22Lgeb/DAXKLVGJOS2f8PRDBOGkJHAiEr1oQszBftSlDAGujxWwY9OPfZuyX0Gbo0Yb6JqVtz/ia2VMEaGDn2Tvsm51eW7iOhVHGe5OMs4ZsWGOcrabLqYIzz0IB46IFmey8v"
-    },
-    "output" : {
-      "signature" : "26255294"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "+inl8C5bwuFpDMDmnv9MgQ==",
-      "data" : "aFtmbWDUZ65ro/CpvicK7fvSwn46+Tn5aRdZSyPX90fO8a+Cms3hq/e5ARnNmasCAWEgUGD1vdwI1Bs8IUWzD+NJUU8tmAJdUKsOzuft48ZNEEIcZg=="
-    },
-    "output" : {
-      "signature" : "70237234"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "+wPD98m+wa6Nxc4yGYD/hQ==",
-      "data" : "HxZmHbCLAK9rfcsCZYThMC0L+cLVA6jz9J3MSryo44DJtijSaHIhuOFEWYJjLA9iiGNwg6lGiLZURKNJO/XbWBKgedQBr3xC8gQB05CnuuB8OkGRnIXzcdgkLIC7uXlV69mdNphP0W6J0NE4QO+AnTjUbYa5sd1ZiyBF36/OElM9I6VS30QKAtaAHyM5Ly0Rik3OKIQ="
-    },
-    "output" : {
-      "signature" : "72806248"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "yQmtUKAGq/reFks4eoAlzw==",
-      "data" : "aSvs"
-    },
-    "output" : {
-      "signature" : "30316012"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "lY8BQrU1+pnbvbPI1LX/4A==",
-      "data" : "1q3OmpHQ/0zQQVYWBGali4I4CwYwASsfZYbNGFVFiRqkBLIQLTXgWo6H7tVVlTBoYyp5crp8Hdxq72rGqwlpsxpy70pB8PgUYo33fSyrv0R7ZUle0vGsS0oPPdErB6kZNb4ZqeyuWugQdcvnTjTaGJOfb8IHL+P6RYK7m/W/7hpNm/unsC0MA0SnsI2TBOm4rYx9MBqNcxxsNa80j+6d"
-    },
-    "output" : {
-      "signature" : "29658504"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "QBMm7llTOdNqBlwoY9Wrtg==",
-      "data" : "Zrq2b5wFn0EhUBK3yQ=="
-    },
-    "output" : {
-      "signature" : "60738788"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "3p1XiPFGDM/Kswwd/8R0/Q==",
-      "data" : "pCM4pz+LJnhAw4rfUMlXSGZVzEc4QY5CG9VK/m0ZefvBJLxw2PAwZOrtQjl4qYY3K5ej2QQ/MucWu/8afIQTLF/peArQevA="
-    },
-    "output" : {
-      "signature" : "46123175"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "JTmEmzO3qQtzOG+7vu1Qog==",
-      "data" : "8TqMr7WO67R0sLaWJSgCC6iv7KtodDqcA6gttuLm+FxWleLwnmeZlXD3AxmoiAnRH9tEMlQtgHAOw5x5IfJUPEx3lXNLWS4mrVCodcAqVc9fM+XdfUPIwAV10ftzeX8X+ubObbBI+q6W2AFDWgN++DVOkUbORRQ7JHOpsGI34ZcrP5h4PzHX6gCb2Ce/r5X6EHeT5N4uCt6e/hS4hT0ALyr71EOzfyZhT81L04px2Wohtqk4Kk27yGzz3ZAh9C/Pm7e/bJZnqckLkTROXQbi"
-    },
-    "output" : {
-      "signature" : "09289892"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "6",
-      "counterData" : "BbyOnPSxEfju2jjpWTGAxQ==",
-      "data" : "XDv1xFUXDRm9I1rszR6Gu/U8oeh1IFQOkLyf/YEfZ5T2We4vAYr3rBkbRgGaR+n9P57cQ0JNKj8ZzamuRfGo/mOROt6gzfyRpmpK9IieqVjT+6kncJj3XrUlNW3WBPW2HR3ase+8zAOWoaTPfvfrjtu2EwHsKTgqMigJ+lBfNdsT6S6xCAMKGX6rAqUXZlGtuI/m7uwM7P2+T7AaUSGxpjVGsNl5xMQM+tzWs/VvOWen/loJjA1wFtC6PcNvvHE="
-    },
-    "output" : {
-      "signature" : "17371225"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "wV12pLXiqaRio05m7V+BEQ==",
-      "data" : "YEkd86PMB81HmsxYtP94kE1MphcoFaaxljLShsrsqZ9dPIVmEr/28s5W7wTEwvZIiFzrbgqqFIJSsXJ1V3NQhB+1zbKJQIxi7vT9it7hmoQsAoNTX2RPB2BMntMRXWQWwouP6PB6opBrcmIV/0k9wRy1cLr/VlT+EC8qVRIAeAspFWrJ63LuW035nntnkdN0WtH97A8NlnwFwhIuYp2HGYpjCb/bseueyRghCTn9zNur5/My3jCJrCtOq/IQKUSWDU/0a7v8IVAZzfyyYPMThUw="
-    },
-    "output" : {
-      "signature" : "39909411-52167426"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "GH/N5qfF/Lkx078OffvNnQ==",
-      "data" : "G3wztnpBb+B/excW7eJNAsrpgloUArR2MokTir7BcYPdryefOIoaEpSusWiuv2lUUhbfo6WXKW1RXVHKWeKDjWIpLtclYqc3slp1EFSq59qKqayWrmOzwXrXSdFInMxwTyt3u/Fj+IWJEvlMc2/faXE="
-    },
-    "output" : {
-      "signature" : "66272542-11440595"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "AAVSYRN6SmNUj10JpAvbNA==",
-      "data" : "oQ9A57a1rk6oOZ03vf0VMgx0pRvZe86bpBshD4Mb9Bkb4RH5tA=="
-    },
-    "output" : {
-      "signature" : "50332150-31082225"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "hZ8lSDEbYiXnyT6yeqF4IA==",
-      "data" : "sp7eNac5Iwy4RuiQlc1kmZ8uGGTGM+8Te5YfzJ4cb4Ho75OvuRA+eDRkJGYoKEx/CyTZHkpIQTUZsczzjZMhXuOEfyZEoXP0IjZOEEzo8FLyd2TWFdFZcAhD79SfrWj5+SxV5Y0GWtcpaRfdVhm3bgDUFYeg9YqtEo/3IuJt7SI9aWXXjwDMXePyh1PVC6xp+j7rE8fQQRu+d8SI"
-    },
-    "output" : {
-      "signature" : "57525017-56820453"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "3NBX6PF5QUAaHoHWl64lGA==",
-      "data" : "hbdTVQr6Z1Bwep0SdPyHVPtuVVI/nlMRbCUUUuxgyqu4k9tUkzIHYbI="
-    },
-    "output" : {
-      "signature" : "11908420-77928905"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "tG37IHgClYCVhweey5YkwQ==",
-      "data" : "oQCpPrpYW4AdHhLhg8QalpREurywz/R6wDv+AdFkSyrKs3MAlfDAVruTc/G/ieXtlb46na/FJkBMvo2Zkz6WXHqvfMbrhMbXsj7cIYaz2ArOYgyRj8H+wA=="
-    },
-    "output" : {
-      "signature" : "98791770-87023830"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "FfZ1GPuWx5Mgcz21QU66gw==",
-      "data" : "JBxMjB2N6993FaCBCc4pru0kVIQ/eC0mMhAGWcgAPw00uhNtSoBFX7ey"
-    },
-    "output" : {
-      "signature" : "91306635-53767166"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "3Ppf/suyRGEKLhQryg+2uw==",
-      "data" : "rThgmw91TDxFjgUdVD52pbzkkXuhAD8VrFdKZpe6ea65Y7j+8IPDPdQ3jywaof+rGwzPBI0jA+OrHH+oM0CwJjULXMVxopO75dvJCrUWvFYh"
-    },
-    "output" : {
-      "signature" : "08020398-97201829"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "ovQrJiHlAita7nxCaNt5vw==",
-      "data" : "DYaXT7qwtKRUk04uKootL4xXHfdjmJ1xOQ=="
-    },
-    "output" : {
-      "signature" : "92941199-30429837"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "2nwdTX/kHNf42xNN4FdFOA==",
-      "signatureKnowledgeKey" : "W4MGeyyKJyeHOUmBmxpFfA==",
-      "signatureBiometryKey" : "Oazia5UR3+Ybj2r/HElh/g==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "6",
-      "counterData" : "iyfDK0i2zKD1jl1OU8PIcA==",
-      "data" : "6TIzl61HUjPvhyzqkJ36PX1QddVnT5Od+H36bm0="
-    },
-    "output" : {
-      "signature" : "98182735-44096223"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "7",
-      "counterData" : "ip+L5Pw0obExXDtcnSeFXQ==",
-      "data" : "rYwcikSPOeWAb0fcg6ogm1+atzRQ5CE+IjK/VcOjvG6cSvknsQLEHoG23YCb7v/o/kGp7JgD49RQy1lWl0FRHo7/zd1AB8HdFfdj9uK45V2jhitf40zdpucgCA8MEujjBey3++C7BMWG6lWRV9U6A/W2EwQTli3oQ5o31z5rok2xL1tdV+zn7oRIJuTYZUVscuvdMxGfPJOKJwPhjkuy4uE0V41xvaG5"
-    },
-    "output" : {
-      "signature" : "87698252"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "7",
-      "counterData" : "XTJsHGENcEFS++aAPFk+bw==",
-      "data" : "raSPOGX3Wv8BmM9Fe/ONBhgUndIF25cQICYvkgFHncmWcLQqTA3S0Ptqhb1a/gChhqJ7VoWg93N+Itqi0UV4BiJehs1qTCCCY1zSRQ7J8gvnrn9jIA1GKQvx6gHCn3jZbFulA6TkBeI2xzXIqTZkmi5e0IOdwKE8GqWc"
-    },
-    "output" : {
-      "signature" : "70396953"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "7",
-      "counterData" : "9PJdXLRge2iNM26npq3g4g==",
-      "data" : "BP0s+bPbICcDRKy9W/QTw1/JqX4v9bZooC6skC3qgA1nKhtEA3XDHVzz8+krSw7wBZRm7ZBipA92fy8W/dA/HUFCiIKu1PmWf1cM2GtUqd6cYNJ2eL/NQ6U8ELAy2lgBzt4uAGM9AGrjcqG4gDZXWp72UJbsy04qbxI8b44I1sbm61Ip0L/nEi3NPOFhnCXLepkaH10woA=="
-    },
-    "output" : {
-      "signature" : "93650841"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "7",
-      "counterData" : "NUCEQmFgd7SGXnW+wCfXEQ==",
-      "data" : "zEVKXmiwaDJD9Y/Q6F4rlZ2YioMTGiT6P/h4BBJCFgbhPLP+rvnznHM3+Vxg/8amDsgxU50lHOx7zIZ+FPR7jZi20PEUQ7t1g7oxumJELiwr40Wtr7o3p6ULLIowgdmIP9fo1o0lGRh9CcccDWyTmSKcG9BMpUcXlAdyMCdpDc0="
-    },
-    "output" : {
-      "signature" : "39364825"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "7",
-      "counterData" : "bVhCyxlpFG3DY+OPt+Ml7Q==",
-      "data" : "wj+VAIzXFRReVSa+u/4VK+5zInSVmZXxqkEg00XzQrOi1707FVS3Kl0pXTJwYEC9ExKihCazMsQ8mMe6J6yHqIicXVvfSBj08+D31GWi2wN6lYhR0WlcylOwo9sW/14O7dc0cqGUOqlWKWoZFJpRCSVB56M+uNZr6It4OGs8ZRz0pDb+eHHcGbc0+yTVHclHRZ19XfMXT9BkL+CPShNITCstAvBC1anQ4/Mn7k0RDqNW7AiXNMVNagZNabuLFLZfcrem9WNIedAbjFBFva77tLA++lSe0HeRR+OVNTYL3qch926iPp2adpT0+ZOpuUrjIBAyFFnEnCM="
-    },
-    "output" : {
-      "signature" : "03921133"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "7",
-      "counterData" : "ZZQZkkxjf1bikyR7w5J5Eg==",
-      "data" : "6asyv8UNEdd29KJbzsW96zblJW8qlO9khSpCQRsoIF9tUah80VZuKR0gRTRaPHUbsE7SxfzyQ9RYB75Yu0wqRzjl+TP/U3cO9W4BwjxzFK5mC+gKGtKJSXDA/iZ9tEje6NtXyo+K9R2pr00iR0tJWRgWXip9qLQKWWjX+zcU6pmi+9Tcow8+x7N058gi15/Cv4c6Z3OT+jhVbMKC0IkCGu6GxPSdbBCnRXC5K4lnJG1N+KtxV7JOXGzxCJuxBwj3/ZiW8uN+j0h7tflKr3fqpJvuZIPVV4S9eKFtv6NZPL1MtUgG/aqBpws/Xw=="
-    },
-    "output" : {
-      "signature" : "02743979"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "7",
-      "counterData" : "tDMyB+tQudfX4jloXBF48g==",
-      "data" : "z3SuJFzNQg81YWS90XqyaQF8MdbBV3XH6fr5a3AXUeQgjtZaXPpzzuuiEUaKUOeN+KashU+CEHdj7vJnlm+efpDN14/6jH7RiXCtDgXtWH0GYfwWkfaBw6Jw7S2VumKIyRfraVW0WWDI2FuVv0Kwtvr1Ywg6YrO+ahJQwHJ2h7ALo58nBbJqCjO4NtIfHX0t7MkADoGUFSTfEN6sKo3WdZiGYATw6IdiSAlAUBqAPYdvUDpoPz5kUoDA7O7TOJzOhSd+cFqCRfW1cCiVUfYTZji4J3k="
-    },
-    "output" : {
-      "signature" : "53114545"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "7",
-      "counterData" : "s/jmYdhwOVU8BuGky/tt8w==",
-      "data" : "8o3j9q2VQ2ipb1XzptogdY42/IfVdscLRrwwhOXaacjAnqco7JtDh1GLs7U68W8jbnD1EThUSW8o1KVZdmUPPHqlGNB8ySdNzX+xJ/y2/OguDQr/D4X8pEOWqtkTYL0/nncDsEQcSpRO/3hVr8oP9Wx7NGTuztNHFrMLz1row8todpIvJhXw+neJ9NOoiu3+AQBHg4tMMJZGWjPsnP6hjvVwoy16EYKPEiuegYijGcIo5BG1"
-    },
-    "output" : {
-      "signature" : "74512401"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "7",
-      "counterData" : "YwmnQwzIbaH9ZkrHxPHFoQ==",
-      "data" : "gHy+TBGcVt+e5zMGaMkiu+crUGn7rDl9rjbQJhb9j8dtDrntUvJJA8jiXdRI5MsfWWa7nlIQFwW09aTPFbuJwDjnzsrNINuiLab2NpOGp8vkfDVHkqR1rSomSovApPjkdVzZs7hAgkwVVxLfVNsRpRhP7Z2riXSNf4rXIKAbzQdfmbbIMS/UI1NCCf7hjjBfflBvcikeqh4jPPvL3IUlc0nokc/aDCwgp1s5+f38BqWvLSE4SNn8QayOihrkEKPp01sJCVD2dJIlgKOwlkf1cy/klxk8pqFsjVj10Q=="
-    },
-    "output" : {
-      "signature" : "98068843"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "7",
-      "counterData" : "YvnC/R/ABtqDb5D6PaSUYg==",
-      "data" : "uP2NSGEb+kvAcTx+L6MfxmzWm69E6jkc4CJZ9b5XmBCc9R2kSLvrjPadr6IEMtE8j2Gx1PO9nycx0V23FtmJogS/CUin/eqzwVmYFHbC9qh40Ur1yZFlLpq3JPXbK0ZsC9JqQ3Kw9QOnPE1ongHaoHMXk7cp2j39oF6vGivoDgUpTBzLkmrZ1ZaZgLo9ta6JTQGTpyyn/4rE8Far7K0FiCsRmpK3BrFt8AEHwtBoNdNRi8//7GAFLd5lLG5TDuFayVwwDK1i+1Nz3KiMyb7GlJvXuh1lD8AyE5RbwVCUU8BSYvwXBeNhHT+hbwiWK1/OFeqOgUo="
-    },
-    "output" : {
-      "signature" : "09397450"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "7",
-      "counterData" : "SfdYTjs8yey8zHMjdJMIhw==",
-      "data" : "WDH2PdfQQctY7NQlg96G5ElXvNUE6CYWmJb/7ClHQD/VVWZcKuqgAFvUAoVSW/ww9l5PpDivOmRmtwuICNU/XG785KfkZXCmJWwU+AXzBKcssffF9FqT0qBfL2vMRoef3+hLL5HRaUJChDuzt+MtSmyAapxykPmJxjU5GEdDeHEQ9EX0bAjFOsEn/SkwEvxzqdeLZUHBzfwstJXBhbdPhPSUwDJFs9YpFB164nwI4pWTGOoJKLq9wfkH1Ef1r/e4ejyR9b2krvNUJcQxWuUg/TXKjCimZMpI"
-    },
-    "output" : {
-      "signature" : "93107143-34961851"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "7",
-      "counterData" : "TUpM+Jq2z7lQvYgspksgSg==",
-      "data" : "WZTELVv2eJH+FlwGa1MDDrUXO9hsVZpW5VEV98XgCwt7QELm7fPAnPY+pB6r+BR/wKuGa4hEG9mXon4aD/JYM/qmsXZ/t6VDhjRZpLDpsVnr3CqdxXBAt/hFV8aN9FnVfGB/NWb/GbcTGsN2+7zpoCQL7UMkaURPQ+RTd85oAkhKXJ4JF0z4MVCZWHBKFNk7kLXwsKgn9qwAe53Gj8j/L2Nm+FVDfMnbAldeu2uhiN+NdKACmQ=="
-    },
-    "output" : {
-      "signature" : "21295609-68401252"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "7",
-      "counterData" : "/NbDCmDzx4qhW3QwI+ip1A==",
-      "data" : "jIT3ItiVHKNi5zXZNPEj1coRuKpJJCyVLyE628cqpxFBru2tFVadsuMsEz/UhHkxuOoTkdi/r8C+axeXVngYysy0Lj9Cd7mYyu93r4/CP408FJQfpAZcCPMOs5e7HwBD3O9XbJ5IIW2565mFkKclWWU2tpn7mP7YdUFsPfwshYaPbN+Fu9VTkibkBionIYojGUoTH0RleZf3nyXLO7hP/oflhiHFvnkCPqpSc4LFRQ0yykBVWyCI1MmVd5sbiccbXXdZCdY6cFQYfkwUlJSGLkV8cBxAu/+Yk9TctVmwtvuc"
-    },
-    "output" : {
-      "signature" : "74709329-58420556"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "7",
-      "counterData" : "0d/T70YnO2pSkLIWKUa1cA==",
-      "data" : "4WY6AmnpyWTzRFsVaF4tZIOisr8pvh97+UnM5RGTlWFC+PlLBsQ2lCy2/TJySLjoJDpiG4MoMWsebY8lWzA5y9A2RC9xYEJV+whDt6O6y2i4iozTXRtkdwueUXJzMxS26Z629Im8MkddUi6mqHV/WF7TvPN9AVE0WRWsno6L0lMyQmpY7xmx5/je47sOI1h3SkXF5+0xbFKXcELYVAKMTg5BYyh0BUbgeQwoV3qZYTTv0VKmVnweB0qbL6BSPBPgx908BYfD/goGvDfmDgijeM5P0jGPX1Y="
-    },
-    "output" : {
-      "signature" : "48329184-78088151"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "7",
-      "counterData" : "QD4C29qA0rRph7fftyYObg==",
-      "data" : "gw8sX1YYXaUzj2poPZITZA0hy/AvYcxmD3iThRgTJYQgX7Jcc9woR4zZGHmpoQwuvtJ2Me2BU5m4fkodguDnaXfDEdDkSPgriDn5oo3HOM5SNIiRGFcF5G+N13aJ6Wl8qSBPncJwFpzEE8QmDsUax+SBa8OMfFDHJZEhyGeWPAie+iR/NOkO1K12hKGBJ2LUxX4SHIS35u+hSn7mK4/Xugy/MiLMFTDf9XY/F8LY/6iPrcZd5e9veGZX74UApJKdNs13G7ZOpY1O6T4mgpgbVV9HAnvdblhY+zj8TsHrcnHY6BYnF3nCNCg="
-    },
-    "output" : {
-      "signature" : "32051011-52005098"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "7",
-      "counterData" : "o9h5cfGzTTAxWfE5z/RXiw==",
-      "data" : "pIf1L+gl67EfUes7LRmAvNAie9rEghMfl6rbjm9xxCBL8MeYcnM60jOaKgVpaO0MN7h7JtVFxy3ysnq2C9np05wLg7U2iyP1pdrnoge71xZNycAw76SQT03fCgwCUDGQFrViXKmsRtnMWgUyYHMAYsDUDvxz3uob"
-    },
-    "output" : {
-      "signature" : "68466865-76662532"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "7",
-      "counterData" : "Kpumkym6h3YDZqsN9LY+6g==",
-      "data" : "UyGLdm+kZvwpYeYj/flJqfUFgKYhz02J1oAehOdoitP92Xi41ZRv8vHzRVC0ychuI8OG3sgO6OThIWOvvGW/0XUjGX2alb2I5N66zGv3Aa5mONIbaoc0qSrjeqrVrrkx4pUw67JGwK1fmQ9ea7UDHjEkCw20oDjTfpTUZm8fUs0E2vhrdgBhBirMU26TfjP3GGRCZ7X6T8zHffD3nFmALHTEZihw7IjlDmkwKJZCM3AhOm/RJMcxp/6BuNW2xpmVwiQFglsPZZ1ElzcmpoDMmWFT9SIe9ifLhnkbZrFqGcFgYjSc8ZWpNGnpPt+NeCUF4w=="
-    },
-    "output" : {
-      "signature" : "08967993-96789237"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "7",
-      "counterData" : "Vtl7oJS4mytVkPvhpIxjZw==",
-      "data" : "rLNoSeWMAANEQjOZLdBhOsxWFmFCnxwllnFFMY+iVc7ohNqi5Ik7W1liqBk3ApMqQuULj56QErASeyuF4b1m1mwnJzjTonM9uhNBFAsjtdN/OIUhfMn/FOGBnd5chHyymMKoPumbOlSgq6pCkre7sIsNQZCBZR9DMKtmOHeIUlXSg83cpWDoSzK1RM1e+OzgSRyD4gme3g/fGmATG52iK8AgeCTos6li7vtoryu606QiG7L3RszOF+fICwgb5dkN2ayOUX+UQVZzpO6bXUI="
-    },
-    "output" : {
-      "signature" : "41658238-07712756"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "7",
-      "counterData" : "DrryBL9QQH5YfrearN7yfw==",
-      "data" : "zCCDq3PBs29NRNunGYVJLIHvXGKko7XJBy24OY9nQDshdjCKFqnWVRRWhECyal8DDH9yszvqtTjOL8F+s93PfLWxAMUEWXfn3LHSGpkWsWdhsvX1c8A3IrHchfR9i/Yer36YoHZ8RWW4zX89EiHr9F9Xvek2cu9QeGKfDpG3JchrmUHrGPTqpLyFkAt22mV4Dlg1fBjOOMyg8XvmGnDWGnE50qhh/n/DSQ=="
-    },
-    "output" : {
-      "signature" : "12182381-95876832"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession_knowledge",
-      "signatureComponentLength" : "7",
-      "counterData" : "2yfsOT7B/fIjHSRgVj1Y3g==",
-      "data" : "IADFyYheqj7aVYZoVOpttA85JTztefrw97e8mX+6EyifPzFcFQuVsMAkPlVai5Atqv2ydMOk9UukLZLQifWSKgFhLb48US9QKM8b5iwCcqUED8mlU7b0X/s51rzpVyXDcLPfAKz7xN7KqQqtkPnvW8r99HNiWEWHGERoxZX9vKQRUKfUxxYgbBM5QQ5I70dJlHS3dAvkFjmy6PeIMTE3S43++iqyLzzPf7mnJHx6vLmO+kWpuNTO0VnP62OyHnYSb+5eOqMZDvK1czISVgdgOmdn8SPs8pR/gzrtNDZHFaVNraR2muctmKp34n/skqL5ODkcYuU="
-    },
-    "output" : {
-      "signature" : "65754407-34990965"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "7",
-      "counterData" : "AXwMhNJNgBie7X+JclY9aA==",
-      "data" : "Aq5OPcj2qzH+YoY9czoT9VGRlD/P4OQzeLc2RzyUJur9uUz6OtlY0CnumtgB3xGRBDaffP/kvztQPoWp6kC6luKHjYKWdPG1ixPttzB8g6XN2I2czh2BPdl3TDdRqLhjk9dm5T3MCu4Ovd9PcXjNfhU7Mnedhgqzi8oTr6E5Pzqsk/VsbwrRqxvnXJfYLvo5GahCzK6pEvs0qPG2R+BB7ikv7Pjezl9h75X0dBTrG5CLuImFKt3fcwpe4oVZAlEgw5Pe8+2qjwymA9a3HV94sGjxLIIhaISWWHvRMrrGYi0v7zGkMhUidy5HUHH0Ln0hIgXZCQ=="
-    },
-    "output" : {
-      "signature" : "86671340"
-    }
-  }, {
-    "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
-      "signatureType" : "possession",
-      "signatureComponentLength" : "7",
-      "counterData" : "gOz5t+up7Ryzv3cVqTgZ1Q==",
+      "counterData" : "iyw3XPbuvYjHgtc7D/P7uw==",
       "data" : ""
     },
     "output" : {
-      "signature" : "23389345"
+      "signature" : "1985-1535"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "4",
+      "counterData" : "9QUbql/cyex0byK/0Agbpg==",
+      "data" : "Ih0I58zipOwRVdZEOtH3JRFRg/orAV0L9vXrvPOc40lPyBeS0oRWKbRU+qp5HCkg/0ELDm4bAv2T070GyOQ="
+    },
+    "output" : {
+      "signature" : "4771-6441"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "4",
+      "counterData" : "zmMIuM0OPY6N4lxv7WzJFQ==",
+      "data" : "9Bo7WOH2P5/8lAX+5tOr8S/KINtLsAouBvOhPZihrtz++YZ0Jxd6pVXIDjxcT+hqtr5U7yBFi5cLjt69LcuwjSR6TO8j0iHmQa8cfgRSbMa+q1Rlf4oFF4O4kH6yPJ0qy7HVgsexldbDR+AdK4D6zkSvKHklb+dInazvQTjB/OEOGHyL0AvbqldSmyIReoy6LJwwkricCY70UIGXGBQCJtiOgxVgSoHE1IYFGtYJHOGN"
+    },
+    "output" : {
+      "signature" : "4840-4995"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "4",
+      "counterData" : "FoWwIN0doy+t5rmJ4gU9vg==",
+      "data" : "wMAoeSEybEkWq9Hn2cXpF+UuwZvNRsCl4jQHp1OvYPTojeBdYRSiEgduYSuLp4yf25Xl9XiJWyLQp3ETPqMV50PChqnT5A//JYW9tP6ngJp2rQ0xeW/alGg0UkhE6pF3kuWpwAXRmx537/6WzGfpufcZavSHQNjWK33N+N03KVrXhnoIkc9DtDlq2MXIbjcUvmns+FHgrkdcTE6R+lN2t6rgeSstDwLGPZNk5Iz+9V5HoXKRnRWH"
+    },
+    "output" : {
+      "signature" : "0797-1638"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "4",
+      "counterData" : "YTjXn6QF//lDiWX+78mM4g==",
+      "data" : "iw=="
+    },
+    "output" : {
+      "signature" : "2611-3804"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "4",
+      "counterData" : "kNiIstnjg71IxFay1jQowA==",
+      "data" : "abxuAAkweZfPunn9gt4xWBs3dlk6z3OXw/Jgu279lBAwa+ly/OE8GOrFlHjEB6JLZiHPl9Dobn84TI09RZBjDoMsDw2rf9CR/qVtK7PbzUQrUObdoNiraU/1Wss/GhnyiOtMfQ=="
+    },
+    "output" : {
+      "signature" : "3212-5695"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "4",
+      "counterData" : "rjNnjg05egjcqty1tV6oRg==",
+      "data" : "zvmVaNcESiJADoa9J5+EUB4akIE+W8Tsv4U4EFCa52J2z6zaWA4EXjNyBQnLVFyS5WC3lDywWda2r/cPWUOUJCEa5PHyL/CGIRYWgVOdPKTQi6lyo9EdME1jXFBgABgO9qBYHE3+WuyrJX6WrFbamgu/TNfHd0aDYQ=="
+    },
+    "output" : {
+      "signature" : "1045"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "4",
+      "counterData" : "OKLLtf8UpjACOVozq7hJeQ==",
+      "data" : "r9dR6Wa+aKb2FYV7yB+CXysfkPkZSx37Nx4hBP1VbixYMJ381cBWpYW9kqLHmY5vAVC8SQr2CK2yBp5WMHIRTmvPKIgAH4509AdNS/uxXwbTR5H+q+qoju20YPqb6Ss9l/K1wtrXiob9Iv+ojb4rT8vQlQakGpbYl8iv9nMgmOanVAmrDY41UQ35KqSbM+vnZVSG+XWzYfKnVA//p80kY73SLgo+LveKKbwk7UQDkX8e6MaVI/S4vde82RHOOKYFAfh/bFeobcM="
+    },
+    "output" : {
+      "signature" : "7599"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "4",
+      "counterData" : "oUSNowK554f9eqaXLz6iZA==",
+      "data" : "F4kfVfAO/kHD+ClQWZ01mGgX2Fah9+lxoo76jY0XtksEpyj4s4OoP/N9BGYPBWU5ZZA55t/BwXVBTESfWO5E3YjRj1ifRKR/KLQVXzTO8N3pnQ/9FK5Lee5/0YDGWNKo1gHiraRNuUU="
+    },
+    "output" : {
+      "signature" : "3148"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "4",
+      "counterData" : "HA7AxU6cwKLvp+MQ1CDlow==",
+      "data" : "/Vco5WYH4nIJXyXnxfdIC8wFnkV8dngp5NHMTwAjs7cjFo5hPCveaXf3oWBD2yBu2axluivJU0nuGJfedDfvJgtyiM4GgcKA/h2grvLN1dzpnkDZWslfzdgiijUOYiqEfPpZ6/vjKMJ7u9oWReX1R7nebba4pWmJ6HbDeA90u0i85E+a9eVHYJbeNNbuYxL8tTRfl/qi6glIS1ygUfNR/fEz0h6mlNlaJb1roLViFDBUGSbpuAOQYg69mpMjeuY+WvTKPcRxIi9ISQwVk86ZT5spSAnveoJ6QWaMGg6faQtw8OjibCHU+cgxb70DJTteEpi+SuERXsIF"
+    },
+    "output" : {
+      "signature" : "6491"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "4",
+      "counterData" : "+lt/hs1Dylwfs+tbe6SsYA==",
+      "data" : "1YYcOOk="
+    },
+    "output" : {
+      "signature" : "2933"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "4",
+      "counterData" : "X+jBY0caNo6t2pm8qj1Q+g==",
+      "data" : "/TdYt1y72QlxgoxtGhnS5JYlMBANRtXMcPKH/mUYgfDcQUCvwaCuQ7OIpQU39RLx/uSChgTeYvCy5Z4IAfeUsJ2pqdrx6fmuqHKoilBKI+mwXXf2afU8WGxaxUZ/PRdkRjwg0/Q7SjwchTmiVCWWcXPIpY0="
+    },
+    "output" : {
+      "signature" : "7593"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "4",
+      "counterData" : "g0LrOfuy6PC/Z8FqXp2zmg==",
+      "data" : "SkGXEdOZ2jf6/VhPDrNvHHrGbQNN6s9DnI058kjDowaOjecUQ2C72hRplmJuvZ62/m9ds8lYhOGdoZeWcS4BMR3fU0kLgSsT47yibiQS2gk++QLHgBUG+vniGO8vaTl//zkPw/FK7p6UA/zR"
+    },
+    "output" : {
+      "signature" : "8218"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "4",
+      "counterData" : "ju/giuJtQnqndlN3f6s6Gw==",
+      "data" : "wCNRBHWR2lmdRMbQWbI+yvENHZcD3laDORh4SYXYIGGrrvRIinDSdDUPg3KLpPwXqAZEYpQjrQT/mCvEUqcHyP2TEcKn0A+Bii63h0e/ocAHrd1eQlbV7xObeo5WN5CpohX2qnHr5V+ggJGYMOY+VmXeuA1pew9CmOUSL74X+R7fOiRIh+1vaIeCxpBQ/JPjSasb7geo+A=="
+    },
+    "output" : {
+      "signature" : "2656"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "4",
+      "counterData" : "HV+VALhhvFNN11hCm8IVOg==",
+      "data" : "0iafYx/a6wMNl/282duJ49QZEuA50JNOmIhzP288rtMhb5v8p4/NuZaYZ8h2g3i0eAyAHl5dgYaJUWDkQ5Q+Bbj6+ZsEs6FpSG+dMhxGJ9PGD4Uvw/UXTa5ZNjE6qACp2DS0cOGQcQ=="
+    },
+    "output" : {
+      "signature" : "3896"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "4",
+      "counterData" : "HVd0imB4zmzuEZSwDaVXzw==",
+      "data" : "F8AcMhkIg7L3DYblJDt6b8vop0fGKuI1SfmjOUi32vn4r1IVKv2XwnCuUugadv4sdcokD8nfopwxZWzuChpXUn3kTeqDNQQ6oGs+UdBQTDAWBX6IP1Y1RB9Y4zXaE6M2+bvZh9BDwlP66h1zBJn2N4W1CQFQvcNPA757FUZ/xtJ2+d1QncYaHnMRGnfP4W/i6zOO3EYeTEEkInlXoLHdwI/YNyXctytdOfKaI0m82rLAE4DhK2xKMIQIG79w5Wi68tF82tvGQNn64XyMR8EFZyU="
+    },
+    "output" : {
+      "signature" : "4603"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "4",
+      "counterData" : "uh2lr7S5UINXSb2KOu1WlQ==",
+      "data" : "i4wQZGMy9AGhdKCrNX8E1K/dpPMOokFpILqchniUZl+gAqPnmrf5T5Ae32pW61HIbz7COeYiQLNww4hAauc4Mj1wf2wSpGEFecUo+AI46jVU+PoQ23j3fqmoxc99Gj6hofHrmAiWJOC+oyv+lUX9Ew=="
+    },
+    "output" : {
+      "signature" : "8640-6743"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "4",
+      "counterData" : "cGkxaQmVUMsi418M5p4cyA==",
+      "data" : "2SEY/g3CiTkhAFab/rYIFmqzpk+3EPigvJt/7rfwCAmA"
+    },
+    "output" : {
+      "signature" : "6033-6800"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "4",
+      "counterData" : "rdaDe6qmDkcXuYkeQUT38A==",
+      "data" : "9oO4XsJHSVVn/xckIw=="
+    },
+    "output" : {
+      "signature" : "6904-1125"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "4",
+      "counterData" : "0j/sPC8ULMo7Qkx6kgJWfw==",
+      "data" : "UD0lZeu559/UBrMa2XPGnUKQlqB1PqtXPgip7g8Nq5TsRQxqgfnPo9YD+y7MpmA2ASVW/RyIIXo5B3ucIP8wyt3tKsm2X7WsTFfcjyEkuBzkWmP6ZQRszGPPdnLSVpj6tA8jv5Ai6kwhJI9BJV4LZlCh4Ums3q/FtDlq3UStp9J8fJWTy+va+HEsABNjz5sw0AXHBZ7+msmydKyvr3D+2AYvonTE3JfqFKLCBA=="
+    },
+    "output" : {
+      "signature" : "1911-5120"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "4",
+      "counterData" : "7NRybYRbaaQGEJUVaxchMg==",
+      "data" : ""
+    },
+    "output" : {
+      "signature" : "7641-5102"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "4",
+      "counterData" : "aopcFMGg9B8u341QOvDvvQ==",
+      "data" : "g1cFNryiOwv/2dD4JKhqkZLgA2jBSadMJi42IeOGbE4yFQksmA4d5Jabsni1lJTp7CBuHDd+sFEhfQlWY6q4vCYVUiJYbuiJ70RfY3IAF3WOWQziyY8l0X7i9BZpEsndd66W6kMoy/1Bmk4ZK8LHP8N13blusrBwMgzNRsdKZYYaTMxDwGAlU0uPgmT1krXuHn6ClTlCPOLBC/FjKv4ypHQlG5ux681sbuKTwvdgwoxeQQ=="
+    },
+    "output" : {
+      "signature" : "0232-3557"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "4",
+      "counterData" : "bZYlwbd8/AniA5/P9LrLDw==",
+      "data" : "iL/sm3njLFXpd3GTbNTZNlHdC2qNZcN2qbBQgU5yIkAbyZGNz7pwNigvKlP7tLlf3lqiilG2zPfatncI0/AhWiXnisuB3wJvYFKwerX9f9v6yygwk1JEesoiRayFxwf7O4a5b8LO4LrIG/maCYIMlbo7Ior8G8DSDwV9CI3V+0v26ADTQQhdOUQ4pB3XUWNQ2LshECnzSrYTU8MdlLTY2ioO1YjCD2ft1fLdKp1fc02Zb1CPFbcZ"
+    },
+    "output" : {
+      "signature" : "0544-8815"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "4",
+      "counterData" : "2HrO81s02dQ7iT8jRrmueg==",
+      "data" : "KhDuE2HwUf9hw51Td4IMdpwODktH3OzE2zBQCgPhdrl89NVkqQuKgiBZLWEYX5xB7WGdGyXEf4bSDPpxcYMpBlFjxR9/1ndahJj/8TYfSBSAsJmSUJ2OcJ7dYY+ZYfSC9wUzDN/dOVp0IuKAhotBqDYyeuYdGKbya2DAChstjQ3J0HC5WHRnF6wtDMwUPA3rdmUCFWtPXhAsdDg="
+    },
+    "output" : {
+      "signature" : "5133-5612"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "4",
+      "counterData" : "TkBFqsrkKNDtEKnZn9ymDQ==",
+      "data" : "X3qmj/uqIQZ62IOOsalgNVOmLYuUVdf0HG+eUjzcdbs0OhkWJArEPO/MIv95TeH+IaavxG6ynXAvEEe5C1MoLFilonMVSBZIP7G0Xq4="
+    },
+    "output" : {
+      "signature" : "8988-2270"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "KusWzq7wrBAbNT7mIuDZPg==",
+      "signatureKnowledgeKey" : "PQluu2bG7DVmhQEXPoPv0Q==",
+      "signatureBiometryKey" : "XaTZk4kLr7g/749M7tBRJA==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "4",
+      "counterData" : "Zf6zDsMxa37IysjzMU12uQ==",
+      "data" : "meiBws7p21I/gEhyNTVDrHO5kia7xaowG/JX8PxXX6lf2T9QB+uzdn0F+xqTj1G7bTR1682JMIs+d2ba2YvOwYvvrfE2XHIgPqFibZwSjptCO48eC8dBUjhEqoAF+pESV8+F6w9kPHwUiiBmebojAFZPT235HnPzDdBU46gSn2u43TrjDr4Vj3NrZcJ1Wxky15CEW6elPrBC"
+    },
+    "output" : {
+      "signature" : "9146-3131"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "Q+ujDnLdZkaujFsXWWCYVQ==",
+      "data" : "1F33flsuEiQSdq/YaDTel07wLrl66+qZ7Nf+7FWhJrQnXLJLTfIEcq5Uxw0m2aOnnVSHMWvnZErr5mYpji0JWxQ0FPCau4KUTcGqUs/NSXQRmBVP1UhWKAo1SObbbP7pUP5RmW/3Gc58s3cpLSazqd06yxoo8TupXKDz3wSSjIol95VDPch8TF7MbwP5ad2OwG4w5bZO0OmC4KeErB0JABqjSjKVhgYd"
+    },
+    "output" : {
+      "signature" : "66635"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "L7Hg8SxRIZaBxh6Zk5ZEpQ==",
+      "data" : "M+DP2l9u+i8pcWooFmD/3aaxdMEgZS2vGyZ1GVtmMsZbj/nQznMm5fiIfj1aoJFjy+2ZPZMua6uEYs6nIjq5icGmxRtZo2TqeOnI4SEk37aqA/7nNH5KXP9RMSdOt6fcv/YAOENUYcjtitJFpoD8zad+K2ENfPWOTiscPbb/aC3HeItv+lFot5URSsI9N7QBbdsTauLbeSuI5TQyIagE3cKQAYFzq1sZdaFOV7K4RYBCDAh3S3xsFd256isLv/u1TWAiLsSBCw6LWuBCSDZI2OD7SnhEq2HY8pRuJssXhfH+8DKWj1K7DlU02r0QqrVYAw=="
+    },
+    "output" : {
+      "signature" : "78654"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "+yjAaYslcfq0zb8uHVHyfw==",
+      "data" : "wq+kBUKzzvwGGr8JWKQqPcA/aaEnArjM8HP16N4OKhTmW3DvTGk6y27L3G54RqVY7hCaVhUAoQ2ku/QSRLnGn57jC8nk6rsVafaJIzZr/b4dYBp+HYGPfFpLZvyxDVxGEq6TPnIWbeZUvJchZV50OSWMepQZ3LjvP4tarLZkvI7UlCHCB1gYVCdL4zSDrChsP+NBEaoSPo5EeODwOf+ehd5kCQXkr1ctlQNbX3azbuU9ct1SOFo4Fqc="
+    },
+    "output" : {
+      "signature" : "30930"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "EW2iz2s7CTb19S0rpoUSQQ==",
+      "data" : "zJThR9/PH9K8HJ89Jxo4o9g4cxVoGZRAgKkHo6p9Q9r6+Fq6RK9rvkvtGokwr7gK3FldMi5WXMF1TBg4C/F6imRVI/bYJrWgqqceJF0o7DMcMKrxb9gTCAV+"
+    },
+    "output" : {
+      "signature" : "69398"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "MqolbE5LZXbmMfm7O3Yrqw==",
+      "data" : "BzEgppugY0rTzy5cnMYysq6ptM9mDPzuPSAU+Cr1zerTojkHKtDC2T059jiT3gjXdcg4H52tvKeZLyx5S1NIDTuGWiG9JADkw8Oh3U3MLVVLx8kzL7BBMMQb9pg="
+    },
+    "output" : {
+      "signature" : "26178"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "IEvIfOUifegmXIKsrMedUQ==",
+      "data" : "9cN3iO1vy04mbQSkgc2Ir/0wFeHdqGm2t2e8WQ/UKqEdb422kh/vRomIzQOo3ORANBIICkQorWDsMdGDRJLRPuzdwOa2/5Bm3uqdxtr5uMtB9fCGiEQCpFfCHM96ySaDb1YUv7z+tgVg5O80AjWRd9NSiRnWTP1ki+6drz0C6fxEeGvVIF/28+viYY0mgqNmw4qYp+aPxMBYSQGuzzlK30kb0gFQDvcjzw=="
+    },
+    "output" : {
+      "signature" : "34568"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "DU6QG8UaqLdmVqAN85lRTw==",
+      "data" : "Jnu9jO++bie+XJjymg4GVeNZWtsxb2cYJEdJDkfMR/sAkoM6JcVb293mvMUuiiqe3Tz81E7PzY6qoPSiDQp6jl1fhN/LlJlSntNCtoKcZHj4wMTKUywhLy0Hr74KoFAKT7R5owbc4NbIufyG4zKrqN2P29LWT17MZ9oeae0gz/EWD/2CVESC9Omb5BRonITtPxMc6n1Zqiw8vqfFpva66SP7mKoVEeRmfTpOJA=="
+    },
+    "output" : {
+      "signature" : "20707"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "TZ856HMbWqSS9JjRjSxlHA==",
+      "data" : "9jK3hHQEl4302I8bxrxrE5xSLli0jwoJ7UApqPRA5SRfgWtNz3ZFndOaGehxL4lm1iUw9OUqTQwP/OLgplQxFIicglQwobp3Ls8ngvr8QcqTYUio11FWpcKYv2dw2jYGQPMZEdyIwnHn30aVBKnrOQ=="
+    },
+    "output" : {
+      "signature" : "48183"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "zPJ/GPFZrrJINT4qIdIZLg==",
+      "data" : "X49N66pRus0Im5TP4gSWKRLsR2+i8L8CgkMCy9ipCze6kfc0g2WdehcX7skVgONYAfppHrvSVq9Cv5QEe5oFIJFNYx5Mtq8PC37QXt8mvEY4kGzG"
+    },
+    "output" : {
+      "signature" : "22598"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "LjZZM1hbMgG2akQ6K5uYoA==",
+      "data" : "8JrpcN0cABUbnLGAuj+bpzY+wqOSDVWULUPklO3dF01huEZ1IbSvwUZlhVvYMSvKTm6hd58J+W2x1gMf/JlRGDNUJRyNEKfwiQ=="
+    },
+    "output" : {
+      "signature" : "60536"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "yqxBg/Juxs7AHBl2ql65Fw==",
+      "data" : "gJUTC8RLlAo="
+    },
+    "output" : {
+      "signature" : "99183-38557"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "THe//qWIZQX7Pd+/xdpGng==",
+      "data" : "wxSZGdod9w+3tmmr/Ywypv1vGTIQy889PhKABS4vyJE09SdyIGI1lTd3lx/UfJheZFsy6/lFS9UgM/VtwWwB6Ftzu3Dp3Kfej3AYCVqw17zr4PI6+VILEnNgeaQvBlmZnix42+VOUBnXLDLrh8E15ax0zbot0i6c247VqedLgLRKhJQwS9GAmsN5zYu6tV/r36UcBWdFQ9P8gP0JSHKfiKPNhJu6M+EDBm1oFf/B1HJwpEzT8jEoKQcC3+aFJW/lOzjcxUo3qhg="
+    },
+    "output" : {
+      "signature" : "30381-13872"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "/s1Lp7auDEyEpVnpeIJ00Q==",
+      "data" : "INu5HnWzjHONViw/EGpVy4kLIvE48y6jwvYk5x6eZgWzRCGt6cc2TtTBZby8VqqwwuXLUW/vBfVxiJxaknUNUuTs2Fqg68oNq/VxPJ/TH3+tQT5VBD94ShmXpesslw/XSt2w/JqXPUOux3am556vOwePIzpd2ivcauPM0WREYkuoavB/KGw03A=="
+    },
+    "output" : {
+      "signature" : "88927-82232"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "XC2PZ0vzGsgGlkrh8Z7zjw==",
+      "data" : "7IrPEEvc+rHXs7b11bC2HHkXDhKqQ0wAkbbI9i5UkqP1q9xQ0uM2BSid+8dzdz37SqIE8NZXqh+Bv5TZH/foAuXZoR/B/tx9Qe1sxYgBTfy4dJbp0/pEs3WBMUOxWJRLiF1eftvu6RFdN18/HaYY/QYhbsS5AAZQ8SGiPKAbb8dYjFJMwIzjqYo="
+    },
+    "output" : {
+      "signature" : "37882-03906"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "fwwF7HODLjWjec2nPrzDmA==",
+      "data" : "dfppYA8Ji3OkFY8Ixzs2PXHJqpXHnvCxzWo6AYc6QeuW5UfiHWM+nF7xta5pX8tD6p3S2gBb4v8coUNwIsT3Yk5c+XE5bgY20w1W9/khHY3G87JUkBbM1r2sCq1czgdY3w6mN06BL1xHJ4sMUyenupDLOYO6BstihxXQ4vvjr/QZ+TYVOm9dG80/9qLJj6s4ivQjymVmRxywESMTKxRdQmKqQ8HjDqzZvVsyXW2z/7H+335WQOyN2UQXLvtDsos="
+    },
+    "output" : {
+      "signature" : "82510-25881"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "Dnnqle7Ao43QHU4PtrGh9A==",
+      "data" : "C0KpvEjv50ZdDF2lhJuiGX/G7wykpghuGxBa/kmNBHqXsm/5wGsHZWx1TITjKvi7oHlg7obwsWXFfZ67esalxNVJ7DkdBt85lFgJs2pi42qy634uOIASD53XABZQR8p2y4NP+cCvR9NM9+KYdVB0kM9aB30dmAE6o01ftZMk8i9YpllIIN6Nr+sS9LXX+MNeXfl6osoWV9Ch7Ex+sS7CocRNuUUZYnNHzTI4/qPZWg5GCg=="
+    },
+    "output" : {
+      "signature" : "29126-89290"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "kuaEmuxJKMX76bbSv9vBow==",
+      "data" : "x/3Bo1c4LFpKGXFlKXwEt2IJyesHJ8E3j4ly5yg68TK/jeXIJ58NUQ2wz0fIojDkTKC6m4OVaqYif0MU7u53PUKw/vR6NnsQYSWE8AqVy9vn+r1OIQQtf650yC/+PzWjTipMfVCyNIYv7357Zjj5WNiU4onzTesDmoX7VrcNO13YSJpT8qSpA2Nih8B9CKLesfwX9y5ECC4S+Pde6h1nugTwVntMBPiQgVMN3dc/36P6AVhMZo5h+Vh3DX/ZZX+g0IzATUSejnlX1bjf34Xwp91IBqXpWuFiqXmzEM1CuaBnKGFUokKA/Q=="
+    },
+    "output" : {
+      "signature" : "21463-73713"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "LSAg4FMM8Y6iLzGkMh2FaA==",
+      "data" : "QWpyzDKFsnG9pm2e4kOCXtQdHDkHJHwMEC41VIrgO19/3i94pMWzIdMsPevkhRIbPUO4z5UXnBALUcFqHN8gnQhfQUWYX1ddfTczmVjAAVsIBb1ckRY1Z4sw2BVGWZcxMzPH0dQzNfZtrsnuHbC7BJ8nTvehKXVONcBoJcI/CG+PvrWpKcGY+ySGu/xH2A=="
+    },
+    "output" : {
+      "signature" : "32924-45565"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "LrlQ+/2mk6UhJJTx0Q36NA==",
+      "data" : "6X4G1LTE/sb5hOqX0MnkyKnsBLEduFUckgUoCfdYezZScFTjdkPRS/KfsdgMpKoqbofalcxJoIcnDVGwvoxdVOIoYpVMBbtbadrtCzJkS/hgAs+Hm6ue9no3SQpxZO3vye2+4No/lJDUyPZG87xOKOFejxGkL9HEDy6zwT0ZhEoHJ61iLwxA3paC8+HArhOjDf6xlFZ/rO9YG7jfYkj6ooxT2C7kDH4BT9nLISaNd8k4gYAYKd+skC6tOTGlm0QeH+Q2"
+    },
+    "output" : {
+      "signature" : "48321-09909"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "2OfzznZuVqv0NUieftcHyg==",
+      "data" : "OgY4nhME8swrVvx+wAw9JZfbFFeJa6gHrKJo9W9hGsfqzX+G0uWtEr694K+9HJ9PbPr51s5ZUhu+/AdnPf/HPQcMr87boZM9gNQ="
+    },
+    "output" : {
+      "signature" : "25320-39754"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "tZ/pBgG9jjzEIWUCRHxTjQ==",
+      "data" : "ZEVTiWm+TIU7m1p6LovMZetc7N/nERRgO1cqB5ycXiAse0M3TlIpmVSQSqIwNM5dqY4kNIOV7g8ohFZ3vOvLMxzFk56b49IeumcUGFlRwb7vp0ZEAKzogBs+G7s+2ypo3MTZQ7ENO1PnHBMhvMRuALxFaPgbaMQEJwkAq+cTuFJ7GOWzrilpi9RmZEL+thYddBD+RZNhg7zLka51B7sSTZypktAoLHstZt7UcIBWmETnIHbLvubWzE73tFJqb9zkK91gEypzvAitk1zpFb/9aszYKM2xYbGgepxOE30rrq4eGZWY3QbPqw2Ot4U4jeQ="
+    },
+    "output" : {
+      "signature" : "31570"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "oBqXao0+CjvRKkPsRJDjPQ==",
+      "data" : "+1J4Ll+FXNe+j4eKsxNSnoTqlexZwUfT0oJb1Sf0w5XmuRv1jTkmjUr1S50dbhS1Jd5E1Pm+Yu2iQI3s+L1OXRWnAbHBmxoCPsWd7bFzhGnvAQ6jWx0WKlPZGYLvaRs="
+    },
+    "output" : {
+      "signature" : "64961"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "dQPwJPknxQaD77xxf+Mokw==",
+      "data" : "bLg672vgPN1A5R3HDatVwo4+MXQw0rN6x7T0YlvO3Da/ak/wvvZGDjNyQJe00mzAlt3OFV0hkqfQzMuxiy8S7A86OmVPLhUs5nBmOw=="
+    },
+    "output" : {
+      "signature" : "31506"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "vmXA+f0mVRnQ0X1tKQYGFg==",
+      "data" : "xKcStZarZBSQtgd/SuMKoZtCHXfTQozvaU8QWjeqwhea2cZjXUvyv/KfNAVW5YpsDuRIIdG8iAjDPdQHYfqkAKC/Ym3e+xE="
+    },
+    "output" : {
+      "signature" : "41950"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "na+6Zh6SGu0h5tylneBlYg==",
+      "data" : "ZBUXXeOkK1SVwE4GN8NAZkSAaJFQL0BKEi6hiKzJSiHuAn40O8i+ZW8NviV0mIQwvjFWoIZpfM+lI+HG7FEe8KZ5RHCVaF5hdLofszSVVap6N6LQrW1ORXQh5N51NAS/Jgmjj6ki6iogpv0khFznacpV4ciHmEBI2M5YUVuknsslNVVB4nfKbOpjD8UnVhXXvI7+B7k="
+    },
+    "output" : {
+      "signature" : "82411"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "ESoPXDOXRM9X9LzpX76xCw==",
+      "data" : "BNr8hu+iDc0u+M+A8I5XgXZzAABx3JHiLm00EBsnBs1bU/Xnf1gN7ET7wa+02vSNlmJocIe8ebVQgEU/VLKCBIN2AQt2ohnJdMw+qpD5hxTJygw2"
+    },
+    "output" : {
+      "signature" : "24933"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "GTQX/vFd6NcBvtUd1fajzw==",
+      "data" : "gpxd64Z7PBKndr0hS6HnbycImU4OOT7heaNSqR5Ak0niZz6T3zNa4k5DDtgNdpQ32SIgqvg9E1PxCluokmkUmfs+wymvQyi3U9wuty4ohCStABj2yGR6D4wc27GLD78xxllNy9KZV83LsGDdAd1UmtAIhavdowC/FEp7iqyp4YDpJzZsCktyMSSSBlu94bdE4UE9J/+Bn0Nq2etXezU2BQ=="
+    },
+    "output" : {
+      "signature" : "82291"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "46NWGTeEjvIKn/LReJJ6wA==",
+      "data" : "QnraxY2XLD7HHssxo7k4B86ba/y2OK6wpe7I95z2YpuxQs9wMB6CGVxJmW5KKKCZ40NtnJ8hS5nhm2v5R+ieMzgNleK0kG4JyeNuOEiBgphNlgv0ZsX65Asv5AhlhokKD1x2u2GfdVw="
+    },
+    "output" : {
+      "signature" : "49252"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "gfz1ZgoxnU6xu/2TikEHpg==",
+      "data" : "JFY2Ng7MSwXIHhRrz/3NCddD4aMZxwDgrYT1gow9FvYjiLYvB8L9req3UZA94AkVMaYtFGeEXBg="
+    },
+    "output" : {
+      "signature" : "75449"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "5",
+      "counterData" : "17xViStlcb5vzrnxiAqPwA==",
+      "data" : "/jlXTKKqdaFhHAcMU+mjAnTcR9uS9DexfGXB"
+    },
+    "output" : {
+      "signature" : "21230"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "Djho+Ned9wzDBsJaTcpRyA==",
+      "data" : "eLcM7+l/Z/re9N6Z7JnJja7PD31jDWhgbLS4DHq76/BHelDs6nXeWKZQPlcbX9AtWNHQCHEsR8zDMY2TWbIGAw0ffjpjOqgF+XgVOCf/pofom+q8Gg/WMh3MfK/Pxomh8Q1Eho3t0+InCUKwRWahNvUmMAvkocFFqX1wdpxqBB8Qs+GsfNHG2AsIlPgnb4XxF0PJpM5dO9OAwI4XC6Qf50uBggdKcSEpKZ3yVd7R8n7DxxnR9Efl1FnlmcrHjARtEouqoYUit3Z8rC93IqLJL2oSXw6gJEKlBHtI/TmlCL24kyk2MgTvcmYxNcmYFw=="
+    },
+    "output" : {
+      "signature" : "54981-75960"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "0HPA2axcwJNjRWMKet8x3A==",
+      "data" : "xD2KyKogw9mf3FUMHDWfJJ8fp6HzQIFe5b7wkjGmOa4TfnaaRC8AMmD+lFREv98ZMRuWIQPpnm0fiTqzlsyxPQplAA4XbR6RWD9XPD9aS4kIXHUMwLTPevsfO7X2neyXhwj2BeQuRzcSKQ7VsKy2pJasE/gBcWZqnwLHR7ECsL/hWYZyQsKSecxf0sF7TSuArQqoW0P1W3UBGWcoCmaXUx0="
+    },
+    "output" : {
+      "signature" : "19157-44253"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "qjG8GMtcDnlcTMaX+UbLlA==",
+      "data" : "FseutBjRHBo/y5EmMG6/DGZdm8cj3+f9+XUL9PmalPZcqFVIqrRxSrSe7MqkYmn3cA5QzsKLnW/KqWCTDgfzPhy6rAx1Tmz5aqQrMXZBo+aM5NrkzszUcikrHZiovpsShAIeB2yiQjMeRYoLUMxuo0JDLhXpg8nzvqI8tQe16ve9n3ejTQwo3uD43Apqz2BEFlYP8uhSNux8ZnIM1Gq8DHD6dILCu6Vusje1KB0e2F059ZtZrxQNSSwTSbRAoNZWqnN/jUMSrA15GkzO5HeSL9csrPGSOj3tk6dHMtILhe35jE2sDc6tV7F3WTs="
+    },
+    "output" : {
+      "signature" : "37069-36663"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "70RP5FXXMEm/PNfJlpRCdQ==",
+      "data" : "pH5JzOy7vuYuov19Je89aJYRncKhdsTBxYBGYF+q3HLJ8VSfJwUdc+VivRQ="
+    },
+    "output" : {
+      "signature" : "10228-63361"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "jpzfSDc1tI/FnGs5/fM9Pg==",
+      "data" : "vYoHrISZtAr48jd1WZAq5KIcfxM8A6+T4e4z166Ifq+4daRW7soY5Sg82518GZaabaTndvhIkQFcECvClyFMHjAR33r0dPAUmr12a8Oi0CmdM2gEGfq+tmDqtTgrqlQX8uQzC7UUhc9aSw+J8q02AdItNVN+O4JSnzGWHNOno5eI4AYZ2X+RfjmjhPPafw=="
+    },
+    "output" : {
+      "signature" : "78949-49843"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "9pBZTH9xqOpaqMgv1WBfbQ==",
+      "data" : "5cC0D7PqGXioPCByhF2xs/XvCrsnNsySSY9oWIK+n3jiFVQvrHaReTTGwkNw0uoYefHVoJ+qrY/gpg4BL2UJ93Eg0NvSBGFTt1kA/OfXgHcrbK5ZBMsxm4NOtQJU/zT6ozNmZUj68d6hL92RjPDoxT8hPhnEgkMOUnrCbt6yCx2LBxpZb+NLRBSZyJdtjqI/Um6O7v4Oqpf5QqQyw74VVMjbHxg="
+    },
+    "output" : {
+      "signature" : "55828-37027"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "auJtb4Sj49bvaHZG0GQAww==",
+      "data" : "Spskt7MrKUaJci8D1YYjamiYX+ATdorMrE8wM0Xa2RZVH24mW1XgKKoYWa/1Jr+S4l78JlWWnYw5ntuR0smykfNVLfBWyxNFbs8Ev6HDvU28eI0lbYFv"
+    },
+    "output" : {
+      "signature" : "81872-51126"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "0LRgWyud73ofRVgPJitshA==",
+      "data" : "wwW8u8ktBEuFTxgr8DTCsHnyLrL1fYMn3rSDQPoQr3aBTzhcX/F3XsWDtb4B4cV9U13EAv3nXC3b/hoCG8MU8zg7dGXndSCtZMuElST7Rl0pz4DpwFY="
+    },
+    "output" : {
+      "signature" : "40207-23448"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "n8wm54zNQ1hDLH5OIgsYpA==",
+      "data" : "mGsRAY4oWgHO1dOIAKPyRgh8mof4KuIVpqW4++b7fVQVIgrYbe6pW6C3HLUf3gEN6ppw++jGaIGgpRQjrVons7NUQPqG2ID9koFdKRBiVt3zM57C3GroSmndDp6jejiDekYa3cpxyaxQYH4dOB6AOf4Ya3R+YknAVyUuPlilfjU9RmTKb4eoZqg+I4117e13W1/RBNtwA6Bf36M+h3aKt0cokGYI/LGNX41bS/L+YehaOFODbGCmurlZBzyu3FLkEorMwpnhMxnU+yBbyrNj/SXLyS58yzX2HrF7qcJpurINsk4V"
+    },
+    "output" : {
+      "signature" : "29378-17877"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "lEOZN3E1f0/2bLdxxNrZuA==",
+      "signatureKnowledgeKey" : "F0u7SGCYXPb6p9GhVs1waw==",
+      "signatureBiometryKey" : "46DIEk51PfnFpreT9a90dw==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "5",
+      "counterData" : "pjfpE5AbzAh4MBkvpozPbg==",
+      "data" : "m6ab6n5pq8TBLLxPeHBLIfsyomxBMXwdT14F1qUaFvoTS4CgDtg1T16IStXLG2nVh9Rw0NsLeU5A24T+xmJPRFO+KMqCxWy6RbfSX+0="
+    },
+    "output" : {
+      "signature" : "13032-28811"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "qdwazPCE6zr5Alk9o3hwDw==",
+      "data" : "JJ+Y1S6zIox/pi0zCnoVNbY4Z53dlkzutO6uhy+CcxN+/17hokSm5s+rRI+WvdI8fgDzSYsxWeSMSVtoIBEu4XzSQwzwZjCefgyc55h/vFL2ryir5HPUS8TTmdwFSJMKkmeqT/kWGlIOuNkEML4bw4RFnZ9BBvwKp2X8T4LvJfl/M9lumHxCNcEA5qGzUlbIcVNvvUCOKBazy6OkB6WwiNOJhphWPDFjRkfa5ZAeUe68Woa92p5d4GcJXijHbJP7bWEsRt4FI1aQrU3ZxeB/rP3qENRPmuM0LEz6pTUX"
+    },
+    "output" : {
+      "signature" : "882530"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "BHzs2s1ZAmdQcvy1TN39cQ==",
+      "data" : "xuf8e4KU5ctQ7qpPocf3DqYhmyWtwmqcpU05UwJn5FjRKFWnyuE6+dNz7BnruVymRY4r8iAiDrauHdA+gm7PD9azY3MScgkVpBQve1OY/B5sqDaN668PzjmPhfeshkIjLd003gMRmUTzcZXkW7c="
+    },
+    "output" : {
+      "signature" : "057220"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "QkxLGyn2RmUz9XbYmv2BMg==",
+      "data" : "P6kx2zVh9y5CcSRIwRbs8+Qu81tYA8xMQC/+pe5Mj+4alrFGPeTRdwpvDw21MYTjj18A8vpIhNbsQ89utWSymPotEsIg76MYF1ilx2xS3t7wHV0x9SYfOeI0LQ7W5epgDkMvYL84VXNCzomFPHtXQ2c="
+    },
+    "output" : {
+      "signature" : "751428"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "E/IdXJZjfXZGBsyigUuasw==",
+      "data" : "dhIIOqQhvPU250nYkt+vfj7zKcHzSQ3W83xVAOKFFtzlvd3bsi1eTgAfe/lK/Lv1DSLePZomqgScseKFBlfsO1IcbBn1Alcv3qhyQUhkNRXTG51SrG8cn3UHPcfdNKGdBU3GdpR/gKmuuW+sJfT5vPtEGrjnVeQ/5c8GZ3cISY5uGUtpplFyRHHgJ++1lBw2ETzguYaAc+1HMTfUIJoliGZ5Zy3DNbu7vnKYXBIZFcvwmHzI4GjBlUfoqL28gUFz+Z16jtUNUGGi6sXhJ5e7N0wvSil+CKck3XzfR4zz5FldIyVV3sc81RsVQFPZrO5J5+Z1"
+    },
+    "output" : {
+      "signature" : "386094"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "cBb/AYa1QOZnXbMK+QQyUA==",
+      "data" : "CXJ9rzV8BnIpVbLgBdNdhENnbVhrBuSO5UeVTDIzCW9WIiElzEUYaOgukCYGbpUcfECr5TPQ1h9xA/mXHr+Xz0xu1pfdI4R2zDbxuw077Zbc8ixdD2/ljDaDMi72L143MXbL1TELn5kqq2jt+ndlLAKfv4Dy5jsUTTkBBU4TXRSCGa/wX3C/oeeb7t0eOz/vl4ONIRomghenjhrctTJiygCeyaN1Dqt/oh5vAD+/EKFgWUauX40v3ZAjNfWD3uRq+FgH3c8RKzrKhS3ZpVvqltWHPTBgexVDDwAGiZqsMmLIoNQuNBq6sCQgsLS21jUtcI36WEL2jAnSeBve5A=="
+    },
+    "output" : {
+      "signature" : "402414"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "CDkUTXjdcraHTE593MWCJA==",
+      "data" : "LLuVGHDTQ6I1bJUKyi5WN67rLR1tdwyN"
+    },
+    "output" : {
+      "signature" : "506111"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "pibObG05/npgO63mJW+UnA==",
+      "data" : "sualSr2dwo5XX+r68Nxrjj/doxlk29szyigcLlBhWVVlCyBLoGhXlPGHXgI="
+    },
+    "output" : {
+      "signature" : "430119"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "qf0d8CIdnB+pFkg/tVrcdQ==",
+      "data" : "9LiePZjyzjzCJUwsspikSeKoYaoR3O/EicBtisJYrpQ+5febJOJHBW3ngeF5UdbQAjKJ6XZ8bLsonG91qV9DgPX8r1hD85cMyoaxH4NttYE9OL01gaWCPBJTVKHDvasRhx02PwaUt++eYOJQ+bs0h7CTdWyZvmqWGz+7TPl6BmDS9JMOXuOt3cSjIhCGJI6eO8S3oV31go8Sf/sCJUi02VcUst5GURai/sR6xJiGQiKpEJqeicC+8dcHqA=="
+    },
+    "output" : {
+      "signature" : "750328"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "1gxMme8NMwr8UBcP06ytBA==",
+      "data" : "V9VyzurTwgQsWlUHwV6apDg3fNGRMP29EykuSqpfTTPad/KPnc1q5IfxswHCIXrww7fg3qgq/z7c/s64v/4V0lL4MC1TkdXypqoUtfC+4UrF7QBjnV0QE7nImGD4TOWdMg6qHwgiPizMoVgi8lYOeP9uJPUp2k6rzOS8ZhT5mYKqyoSRXPOzDAVeC0hCrfRxAgcp1gvyyzyod4+qeouw+ZpMmo+KpNeL0gZSh1tVBAQYO+bYaHE2T8ezIUKHme8MKCvqlBiAqUTDMsBZAuluxV4+tpjA/B7K0S5//4U/Zf05VFl+g6lta+v2GpWE/wK8EQ=="
+    },
+    "output" : {
+      "signature" : "413277"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "y5EalQyMKx3ly4s54ggL9Q==",
+      "data" : "u2+ECJFxpMkQKAcUUMAmzloueGqDdzQUGg+Z/S2s6DXewJ9l9sS4z0oUezx9BBfztYFdUfjW41TU5TFwWhc3UJyYbkIw6JyWSzdzChbwuwllUQ5/VoDl/qDeAARt2srcZ/rULW+EgP3NQlLAqeHVqmXMroRyGC16TlBbvxf1C48latwxGaLou9r014P7f/KY1dBluuCzq6+7jgHZe2nkAlgST2tUkMCqAcBjqjOAVjDrwcsRj+ZWN621/SLPq2MfSlB4QsimHXDntbkqt+05HwQHUv63jsGC5dUrfQJa+N9N"
+    },
+    "output" : {
+      "signature" : "861756"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "+1zJwTKGYsz7+EOWiom9xA==",
+      "data" : "CHw7ESzhE2A="
+    },
+    "output" : {
+      "signature" : "012553-500783"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "C9uqNpqQo1VOwuCDnVmcvA==",
+      "data" : "ejc3c2SWzwNV6GRi3FK2hU85htSVY240Dck7fGE/VzBewVTOFJ1UFQ1NP8YQeXKifmuSYZIsV7+eTEFe1ahPO+3G9y8P5YpzwzfE/oxHtNv8qW72XrGBK+A2iNSbsn0ewskGQ2YtibaJTL6ksoeM+laBoB0="
+    },
+    "output" : {
+      "signature" : "882372-938291"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "XBhyQHLPI3iDaG9MiM/rAA==",
+      "data" : "7f0HdUX8EDLrjdLy9vsdXJru9HB4fr2oAegyKbiYOoqp4q0OlNrw8PeCZsb5GL7jT/8WS9PI7IAFTKoJECoz+SMzq7Db+YHXaBnAbomEqYt7L26xbFA8GE5qRG57oMiXEDUrPj/YU01lKq2s3a62jFrU"
+    },
+    "output" : {
+      "signature" : "078286-785491"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "yAuZ5Z5UiK1YzbPHxAa5Xw==",
+      "data" : "2hJWk8UwwFEGdCaQfgNZDJULB8T/"
+    },
+    "output" : {
+      "signature" : "633048-671021"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "wIWk5lspsFI8otE3Uwh/7Q==",
+      "data" : "CX4BoaLZnRJMcgtRY5l9VaVClCKUVAqXDDm0IPR3SG9ArWbe3ns0DyflJ3/LUMFik+aL5aBBrVgSN1WJTQh2QaFKQh2IYDVvwqhRnLRJP5WvAkb2ktO3v3cvvh7ROmlMnnWLrLPkFsSAlTH03Q3/+6jWDyfildfthL8pgnFfSHvQaA6Kwj9dPRGy5quXZ0zaA8D2BK+KWojrRpacthQFdPLdEIdlExQCC/Wpcwic+i2HSXWtFy5nMA=="
+    },
+    "output" : {
+      "signature" : "265394-081475"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "DUwOVnExUht6e4/S0UcPsw==",
+      "data" : "Qx/eCD0/LXnnpRd08i/jRAITrPWkZ1OZXN0LHPTWsrEExgUYLZwnEIdpSQKjq4vTwVZvqOKmNFvNG1blPU8T3uVyYZadny1Nd6LKD/UR4LTrlvIKqaWXnQKOr7Q/DgLiifq2XDVM8R+sunYOFF5IcvW5NfIEqtWI1fEhrEJO92+dHjEVqhk8LxPDHExx5rkyc7OBIfZtzS/6E8xr4dqjEfIOKBCNLZXkHDVpPq08E+R55exPp1f1NeSBS193Ehn5ZkX4254BWhxkqA=="
+    },
+    "output" : {
+      "signature" : "515338-901052"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "SYWWja39vPize+sQSv/YkA==",
+      "data" : "lTBjT0bpZl3VHdiAKK4K20mB+WR3sfNGZevH377ejA=="
+    },
+    "output" : {
+      "signature" : "113436-512129"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "OtvFncDPuSdpXlVfgovqpw==",
+      "data" : "B2MSfmCPmuDz48I9aEWW38I+GikKRwKowI0nS6HFik+1Fzuqq2oyb+DuBv9njH6QiRy1GBxEJtpr7zLfjkwmJmS7Hhq4EJHSSnNJeB/3hPo8r59OIpM6t9AWfdAD0O6a+Q3cxR9J++CuoEfeE5QRnZQcuJbQSxH6hfNZACrJmY7MZx8IClOWLy0fbH8B6QrXPGD3+5o5LiQXqICxCHQpZGfNsrSYGTXxfNLt7PBV3vkYRWhcuwUGKUol9en3BxGxVT3rAN1ov+P8mRTy7sFc3Vt1IhYMB9oY5xVcKtcblo0M32VrBLK4OgPLSVBO"
+    },
+    "output" : {
+      "signature" : "621966-905204"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "UxdQddemOov31yC1XDs1Pg==",
+      "data" : "4Uxts5IoIb+mmA=="
+    },
+    "output" : {
+      "signature" : "117119-369352"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "PLkq57u9j20D5iGR5Irnzw==",
+      "data" : "Um6222ooJDs="
+    },
+    "output" : {
+      "signature" : "814973-583022"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "Ex/NVo+oK42xBZKr3jkEhA==",
+      "data" : "/VoK1xtr7lXhoMTWVsu2xtnQyx3wiBviLsieriH2dg6YdlSeoBjI2q2q3DDZi5VHR6dR4th4ZdUHm9sUStwOQSyGLwucgPrkAcpeQ9oozJmz+cTCseOHcDJyWdk+Aq6tgvPkN4w9yvk="
+    },
+    "output" : {
+      "signature" : "796497"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "jmeKKNQhorilT1NIS+UjJA==",
+      "data" : "SkdtkA=="
+    },
+    "output" : {
+      "signature" : "588720"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "lVlFUUVv9nkdUauqH8Wkxg==",
+      "data" : "tr/T"
+    },
+    "output" : {
+      "signature" : "331468"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "Ay3B37pHD5eMUC6h13FaWg==",
+      "data" : "KGHhiMTP+Xv3/IUKCmGRjZ/5gVA2p7JRXwfqLGIL4h8AhyYaH5OjUeZWTtc+X+2qVZU6kuZxKblF8JaLxVdQAKSuakkWm8k6wHiWJHt0meYeZkslyC8/6gYTsc/U9TABFDpArmmztRkTuWqTxOP4JtBOx9g4qiuRBLOFkHV5GFufNzsPC3+/G/qltLPqBZevX94ry+x0hlaC3P4ln4cT4Nl0C4IYUgZoiwvkugm09SfTd61pv2LZJrHceFeIt+fIfvWGLJOlws4/EXDKHBFthJi7nPFDIb9K1+Cl4DPMfPepA7l1hLeM653lAPU4cP1r"
+    },
+    "output" : {
+      "signature" : "354029"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "CQmE465uvo0MavIRYAJ09w==",
+      "data" : "fmypDWKd6anDJHH3QoQkHVZs9EkoZaec2lsfDV7i"
+    },
+    "output" : {
+      "signature" : "758905"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "1Y3FviYqLfavf8SJC0FiEA==",
+      "data" : "lGM9CXXcWTj/LA8JlolGEpLQjfqDEESXL6wvfqyC4+K9BgCReUNOglGE680="
+    },
+    "output" : {
+      "signature" : "535465"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "eEU2BdFsCoKVMQL1cQ0Ipg==",
+      "data" : "ToPjtAKK/I5530toTQMunQdtbN4KOZspdzVzKgn1xmFAwMwdjVJa4iusp1a4qkG4sdIDFLa/rAyDFpDqOMezMr+JftohdCES6etqs5dUhY+B0vy7b5QHa5HKaDCt1Ociblxm1+woQNLDvkyx63NcfvG5zL26iLXNDlI/CLZM+piuq56D4/U6ZB8WenDX3G1CbMq4GCXu4ocB2kgO12qpNpfnjRP1iIibh0G5BZsVQu6aP8sfP9/Xe3zOpbnf"
+    },
+    "output" : {
+      "signature" : "631593"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "TxPYeDj75jWWgzOokvXDaQ==",
+      "data" : "41js2oP8FQGqQ5bpfCbB66oSWjawgdiVMFddQaMT//pHezKyYXLOjTw0Nv5Acz2zNhhFfIcLhdfwI8YOQtyAD31IFOE1hy7fgrjzMoD36+9X85WMPn6Ag0QWFe860dXb0LN+ODrdVmOk+vCkM3cXstbhP0K6mMPe+lrEFD4AoOsZBmAdlBqaGz3a4Ol1yVNa6c6YdfOLCshWJVZCGqM1DbJg84mYMxgdlTBmL0wtOcaT5pg67J1IJ7R62xU1RZ8LCXTzfhKAYfnZGQ=="
+    },
+    "output" : {
+      "signature" : "167764"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "kKvCHXYBazOWUAkHftoujA==",
+      "data" : "ZCIeYGSYpxIW8JpxAfR8OIZAKrIA+hK2+7/7HgQjwrfetd9A5Y6Hom0uUeZlwTvFUqH/6Dkjfwt1XgypNjEpDT4gwPuAr03FvZYIKHtUtgQQYhjyapiorzxm9XH0FxlEcv5zXeEg46egcKHfQmPL3HufhjdnGMxqYdb44QzFHII4M2skyk8EmlvMkAU4b7RQLHOgGu9jnGn7EwPFwQCfTqZsLfkd+49l/FaAuXegLjqKse8="
+    },
+    "output" : {
+      "signature" : "494102"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "6",
+      "counterData" : "Q+rQktHwS0tUfyFYPT4+Xg==",
+      "data" : "B28R/Z907rmMXpOWlPKbjLqJxo8o8V3qwFOJLxNHyrg3iYznMoeyl1lu7yKicJ2g2SnuUC8Cq3U="
+    },
+    "output" : {
+      "signature" : "026126"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "si6AkP/EkEndBJj50czM3g==",
+      "data" : "l9uIBSqjJpCZst8uveQH66QU5XtiiEtVnzfbgpddysVVhA87exOKA4BSfbHsxfgJM7LJvuIPFGt34vONiebPlvVt0VBojUSQ8LCsU+o+zWRPLhI="
+    },
+    "output" : {
+      "signature" : "940214-108749"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "8FD7eFgxFOs1uviI9B54Kw==",
+      "data" : "vW7c1g=="
+    },
+    "output" : {
+      "signature" : "098525-095423"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "ah0je/krT3P8V7ZSxWavgQ==",
+      "data" : "kx4="
+    },
+    "output" : {
+      "signature" : "232065-744289"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "GP8+nHhdVHXmSm3maPFm4A==",
+      "data" : "QHy75uSnPnrhW2UPU0l279fyfxOsEvPOf3PcKQrjdoH18IVOBYQ8qf+uC1UKKSK4BLFs9ru7x8tW1TqowOzN9TAHccMNvfxPPzS83fHUCui7MlasaREoOJJghmu0a7PjOONahHWjdOHOj9bI6pPKFzVWm86t/ckHs/xlKw/lB/1JT8sZ9T+OxRA="
+    },
+    "output" : {
+      "signature" : "963605-510568"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "+mUWixfTx8pup2KvWaArcw==",
+      "data" : "Ow2erBzpQ1h88PkUaut2Q+xKd1NE0yaFmydtTqwEu/En3V+wiKcWmh3Lq1M5bjbrDOi0glMxlCRSJbSYvXwXcXOBefBiqSVCitD4KSATI1EQpy/JGNv/7KlswNXq+FL/3+3Jsq/YF953JLmXG2cbDYEmy4kjrZaZuNoVJadV9nEVrcGtJlFgtHcotup4Yki1dLbIDNbYTcmI0zm4+a8="
+    },
+    "output" : {
+      "signature" : "057983-891002"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "FQtVeEsUdu/00Vm8PKjkPw==",
+      "data" : "jPWsiTxsUfZB+0mJ6ngD5T+umxCPMzqs0ZQLPZ3XN1ufjamb+pvuBZqueQINCTF2eoSa1LVjWZSaiVO5Hq2dw5BI4lwUBJN6rRqCeQHiGzSAqGCwE2NEjvCYJKIGbZZTq9sAOHCTYd0HptWE6lLNWPjE7SQuC70XUzjRDZD/we/jdGwQ0Q=="
+    },
+    "output" : {
+      "signature" : "179072-857145"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "/JusZ0Hb/3WynMs/X2Q3Hg==",
+      "data" : "bY/SAMGvCejI384XLgEYElzUS9s4FlDdt7E06yAojxJztTz2OuuTYUOXjLUGkDQkofK0XeCZ1g2DE42oCiDhtbnXtLwunRvXcpgAMCNLnW+sTFeohG8zzKPIowzsPjg+QMJn5Ta9S8hJZ8ULxk1xJgcDs07YaD3kDWUcHthzc8wCEhilOmSXVXuAyroIun+B4Zj4g4UYTMG7Ld6EaOrS6QPKBrBH3/uvYirQwzV78LfBx10pz6eVmynBe8kgbXqpglmYDvIbKBKfvi7TSGJrV4cbdjyJ3xV4AbkBwCoipqHTmNChEhtwvMi1Tw=="
+    },
+    "output" : {
+      "signature" : "626635-481142"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "TfJXPznmpp1lUQQvs4khLw==",
+      "data" : "alJ1npQYmclFJtIzWIN5C5OBSolgsEmmrP49d8psWWvPESrqc+C105UGnCOaamBQFW1n2ubkqb0PKSHKKjFUBRbgZbzSB7c52LYcOweDYL+rcr3NoDRoBK94UtX7J9lZgjGCoAgNYYrSHgNtPnVL4eZpIRxxnwF2d5Tb2Y8JhFWgfAVfwGgU89XhusKzCvl41oY38X5ciy2Z+A=="
+    },
+    "output" : {
+      "signature" : "340957-221444"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "IkQI8murbH7W6RxuMT+niA==",
+      "data" : "i6++VQjFf9Kut3vWKJeU+qkyfjz/TU5mQy2oZIahP/qT+tylVz2Uc83mnYK2ZFX5l3gaDI23nDy458vGoDaZFLRi7dAbMDdMJzjN/TWioRJW2JuKVj/gK9FHCfWFLzL5nDUCb6+obTeelw6/"
+    },
+    "output" : {
+      "signature" : "624025-825885"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "m+tRWysKBgbsuDutT4LvqA==",
+      "signatureKnowledgeKey" : "TSNxTY91SJ43+R/o7480Xg==",
+      "signatureBiometryKey" : "F8T11vQd6LV2rBHV2CtDGQ==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "6",
+      "counterData" : "fkxI+ZwAv0Vt2xyDCMyxBQ==",
+      "data" : "k9Wqvw=="
+    },
+    "output" : {
+      "signature" : "225466-300770"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession",
       "signatureComponentLength" : "7",
-      "counterData" : "BFLgZ7kGykVvTPCwfU1u9Q==",
-      "data" : "ChhcwKawzrpUnbWAMO8+Vq6kDhvm/10N3qOptW3kIbxSHfBcdv3UB9UIx/UJ7j8x0+f6ckLewYJky2/uRphI9AF8jt80Q2WwAR2GiXD3tFr5Nfw2BrgUC174/jsffuk6koSe4coJcMBAYGYhOvJUq2Wkth2zz7tXyCn9e2Gz+dn+t+F3gDW1YgQ/bzG65XEo76wEs8e8uf+j66fCqpiLGDnFBv5+ohpv77c/TSptKT3o5diJ3k4IH9nvTYLCRhQQ4NW+E1KdidqoR1yIwvMcSUCES679+VKTC1sE7BXCC6QkfQRuRyKhboDJYtmBkRDI9/I="
+      "counterData" : "nYVemXaQxhJERj1g3lELIA==",
+      "data" : "Cyz98m0Sn66kA9giPb4OPUtnuZoo9N5QK9g1PkNUerzv2VLBtvIOnoxi/ZHxsqn4E/UyEGuPW/x2Uhv56YauM6ogGBqf/JscYJVkkIAeEbJAW8r4NNd9zEhTmbbAKtMq2ZG+CDG1PJQKzU2ZXr5wB/6gILv1WYcsFht2xVM="
     },
     "output" : {
-      "signature" : "74964361"
+      "signature" : "8867956"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession",
       "signatureComponentLength" : "7",
-      "counterData" : "DbaHAdcI0qvzqRdHpJWgKQ==",
-      "data" : "o9Uj54Fw0xz/+6ngRQ+h+ZqWl8YPGf4iGW1NEONk676/C5G4/OA0X/jqlCDvR/7lU4kIg1OAXWv33duoamOZZsxek98xP8CH33C9z0UEtbIiA7zFoItE0UAukqcqDaGKRm11oWJTBXTFc61CND+sW5BJzaVBKAcIfLEDQe8xyIul4Ztq2/SRWlkME7a0mhadjUHuaslJ9BFvWjOI3BI="
+      "counterData" : "AqMQn0HZ90e3976SRSzWKg==",
+      "data" : "+AjaQ6V9M4N0ZTefHjpj0N34oixmnVxdyTmHGk30n+qt+LTjnB6g8mZcQxmB8TqR1NKR0fIR+mnCrxirZCE="
     },
     "output" : {
-      "signature" : "53525638"
+      "signature" : "1850484"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession",
       "signatureComponentLength" : "7",
-      "counterData" : "mzPLdxZujPaZuauO/4hXkQ==",
-      "data" : "uFCjFCfEg3qbwVVYEwNe9JyetXsW/EkicQrsVrLbGK80NbNQHNcSNQ9AXJopqYo/a+Xwu5CbQ4vWuLHabAZhO490K6g5phWqzKN/z7WJf7OWAQTZuDvERkpWUigFltUA/WMcABWrb5QDDG0Y4XB6fO+S/wiltSNi78YY0A9Q1VOjt2BPe7icVmwpN6TJroaM+Qq6kjMJluKQi4Utf+Nn5k7Gp8tLchTjv2YjhZlNF54B"
+      "counterData" : "sEcfL96LLZvV4WAP/WDoNQ==",
+      "data" : "/qYe38+bYBioALOjs9XZkI8gZNydUS199hvye6OqxAcyQB8VuNzrcuZxq55Iam1eip0Njw+0qpSoPtJVuk1dWdoIQRFpdesqBrTHfTr/W/3Yk8Z3B+X77WJ2KSgWPixbvOuHm44vLhmtr0b8BwxwXVt3UV40FVf4AqpjkbFvmFPoA9sq7qA8GIKw/V3qLXfBX52t9RqCaowtIhSXDESyAN5B5q08hnR7WsONTnEtTdznvphun48T58l5XgdqCCMb0ZM7UD6FP//71iQ="
     },
     "output" : {
-      "signature" : "97582815"
+      "signature" : "1181398"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession",
       "signatureComponentLength" : "7",
-      "counterData" : "YBKEC8Zg2pQrGjQPIg4ALA==",
-      "data" : "F4ttM/g08mGNAcVPJVVpVSbBUCTS1HivE3Iz44hlB6C2pxCkF6a6aZwy+H2B18DMLwRRhWF4CW0SRB4hMXZucUo="
+      "counterData" : "d8FBBAsdy2advGRZfI86SA==",
+      "data" : "ApNQEbwXreKXW4D+5wzuzd8IipF8MnwwkylVqu9QORcwm/Cs2dh6RS0OWty+Zjm3MmFQL6JdjslsH03aY762B1kR0xoww+kG91ijAdhWRnkeARnJ+y66yvuxsskrYmDSYTdea4J81PYsQ6D6eQNkwZC/bGt2J5ITVWa+wvCFuw4M7SGiQE+M4Ql0rqmtPePUsai4ppeuE5cMYjn8rBoVQhKyeOdNOt6LFZQ="
     },
     "output" : {
-      "signature" : "39363687"
+      "signature" : "6927844"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession",
       "signatureComponentLength" : "7",
-      "counterData" : "scpHluzdVOyFYjYx3Km1sg==",
-      "data" : "IwNuBvY2NGbZ61HYxT0NvmVQgK3E+Zei5DPCJB2bBwfeq6BJjUvrSc9QCW+PpJxBlaypNII6nkRm2ushmIz2Z+YgNktEsArxcaMCK5M3Od6m73LWBy7JmL0/3zo+VNuopOw="
+      "counterData" : "mqeAYWIL2LcNAcNohQiU8A==",
+      "data" : "BAqqU1bSpWa5tfxcUFkp/qL8Qc+jA1NB90/yBc7B6j5eCiG2HQ4atqrJ9aK3dBIc5Cyc1Mvdxv2tcRVNKig2EY99ybRLsjiFtTY/BEaUs4D+hhS3brTqxJVeXIJIjSsQ"
     },
     "output" : {
-      "signature" : "47416308"
+      "signature" : "6726791"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession",
       "signatureComponentLength" : "7",
-      "counterData" : "NF/mLd1YTk979nQnEYAnbg==",
-      "data" : "X0wNgcuJITzWh8OQWD0PmrF0hKvxlvd2sqjGbBmBSqCNm7CZFS4KnU2DN0r3YfUrQm0toe8cUZU+nT0pdQotnzzTqKhaCnjOzaxE4rwjrLLUVAXU+7z2dHJ2qHN4cG3Tr+2Ocw=="
+      "counterData" : "0Ss4+Bl/HKYEtJbXgikq8w==",
+      "data" : "+UlNL/dkzKGnUkEV2ONip+TkND/p61NidfhpCdqR+/Az5H3hWlHgzQ9JC/GUKd2qHMsuIJISQr8c4n2fuhdPy5f226PV5Jyr91ZMNllq19KSyFDsW4EaEaa36QJ3hfGkpflmCYtErkcQFauBiLESIw7G9IC9aheOTBrG3GU0zytfS824DMc0ZHyypYL6klTmEsNSTCcu"
     },
     "output" : {
-      "signature" : "96903608"
+      "signature" : "4829627"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession",
       "signatureComponentLength" : "7",
-      "counterData" : "kHIqOEwgW0fuVRK1E0pDug==",
-      "data" : "IincWsdNqjaiPhYYcTjunWzYyaHEa3skE0FEm4VECbhnKRJnOQ9+XiUQATc0q3ok4IEXhTeysaT0iy71io6wIL/pFXbFNWb1q352pdCVhQjsXQm/uxmqts5c9rMhQs9A4x+6mgSLRUO/OPquMluji3BR0z65f3IIMmvOwUxuPNd9EYUsCDEIOEGTyDwg+sreJsam4oH+vPnkHcxBc0bxnWrBIg=="
+      "counterData" : "O4H+YP4e3ovACai46U+1sA==",
+      "data" : "N+ARS/oZDmfJ5Jt54yMnTQqrFBOxOVPgobv60yzDrSShqB+beB4F+Hw8BvWm2y5rkHk7ETeb5yNzWhCkSNRUqAtBA9oZnMMWMdwisphjrstFKSehKjJe1GADA7nwrHZcnnQ0x2qOos6ncw1idXUw4a3q/1cUS1pZznRik07VWxBqxQ=="
     },
     "output" : {
-      "signature" : "33943231"
+      "signature" : "9034160"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession",
       "signatureComponentLength" : "7",
-      "counterData" : "1z+8jA2LI8FHQGL7cEDA7w==",
-      "data" : "Vad1tnPmRN0DmCc0qDVOMZwBeXU="
+      "counterData" : "v4SrUtqnzIBvdmQSHkDcWA==",
+      "data" : "SXXfWlVR+x43vh/SQirRwNgUZIIbap8tx9dsO2XOVLr/HhZlx4uYKWQo8FU4aeJe1ebV84A/8XI9cUyACfh7hhGonXXVIg79/3MYW2340kIykkX5SyB86G/GVv6WbqjjndJuVdbG"
     },
     "output" : {
-      "signature" : "32332952"
+      "signature" : "5659127"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "7",
+      "counterData" : "qsLnQj84qNlpyRWYZmWTJg==",
+      "data" : "z8opKzEMxaeDZe3VW/ljDKPmSakefDMjBfO40r1tY5UcJ+iAN280kZv3Iw=="
+    },
+    "output" : {
+      "signature" : "2410884"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "7",
+      "counterData" : "nk7uQyq3KxT05g133jss7Q==",
+      "data" : "X+ibQUP1acjmehQ3m1CvK7+P3rDYqx8MphDH1kvRxCkLpOoKxgChZAeYfHIZYtpsOgcoud2ckmpNJMAfZbRo2Un+qTe43ELinx0ZoDmujveXJcYhFJdday4VA9dG7zguK66b"
+    },
+    "output" : {
+      "signature" : "0221923"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "7",
-      "counterData" : "XouUYg7nPKykmoXfS2Ukqw==",
-      "data" : "powhtV0ShOKjLPe2uTvAo+t1/T9NCo7GybB2B36DOCs8kSv7LwVkksx5mFtUsLJ9ix+hynHt335kXaU11BZmtujGzrOMlHkVr3UEyp6+MPYQWQSnCihIwOnS+/khzdSPtcpfw4sezVTi14ypGcrPblbMKoQdUOMKG0U92nQ/v15Roe7NQoO1hZ5ArmedHDH53n0amzUOCqhFjt7LQXfmiInCbxFH3DVVhZcXLKsaGcYqYf5LpoC48JRiprKaDVQ8pkEHlFmsxBT9zowTjCmo6tcE1KOtPikZkeK7h2kDO20OjJ8IGRg="
+      "counterData" : "6kUPuWc+foMEV9P1rrlhJg==",
+      "data" : "gnooMNZRVja7B4MmwB6wX7SIi1UA+U/UCXkM9JezvJQvmU1V1qLfpbf2Nj5b8Fbs8/Xa3pw0tdBG6RsFtT5W0eRgL/IPKp43KdqoEpybUEEV"
     },
     "output" : {
-      "signature" : "36664860-35118601"
+      "signature" : "2388330-3792121"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "7",
-      "counterData" : "BsgAWunPnsoNegZpCzDziQ==",
-      "data" : "KHoxBHW+W1lSJUgWllG0YUli2XxG3qoS1udoTKCzX7brZFH1Uts9H3zPcKXAX2XkOGPcFhH+Dqv5xexwEtMKApRZnPyYPmqrk14zr/EFEY/62S/2Jih9ckESskaE0iP29IHTXB2sEnGsqt9ro7bvz0VXCx+6Ykx8SQKrzOS6LLnxiCgD3v23kAeURORIp1CBnq7C+u0arL9KfS8PXYMAClYdbcao+FgDchIh0tjkdpEC4EvHX8SzKzUbb70QGzqQSiPxZeFuYA=="
+      "counterData" : "XnPnwvsKQoR3lKkYSybmfw==",
+      "data" : "IlJ8YP40fJ7hL3U0h3ApDUmyViYs+lwD+OmIMAJxRBZqnfYIZZE1R4RF0rWOzebfuWF3v66/hd0eOadoGkqcCAJsR/qKpDD93tQCbEqE69TTVZU8PdsvWEeRxd2RvAf0X311olPDYYRvrjWVY+KAhWyPLA=="
     },
     "output" : {
-      "signature" : "49594977-31117856"
+      "signature" : "0642365-3217153"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "7",
-      "counterData" : "wJyK7hbwABzY+6Riviizlw==",
-      "data" : "dEFY7s2cFvVyaT7qrkInZetQSrQ4oI07PF4WMjGc9brnq+HC/RVQsy7VjtaoghRKXMTxdeH9IMA="
+      "counterData" : "F8SPEeLIt+hb5Lt/jjJWHg==",
+      "data" : "zdmD9GBTrmuW1mcH9qs1Eb5zr5Sdqz4QX/vGG5ndM/r8w6JCgZQEci4NrqhjWBGX1ME/BXtoo93/i5NKENdqKK8tFGWY5WfGPx4zPO084xHf8r8QAYObSZR+OrYS2tEkst0g9rg2RiIzCWZEZMGT6Nw1hhi42l3Z3x41Og/hLvyWKmoIDe4l2aY/K6KSotii5x55YXHCw+xVQ4EUMh2DFm9WFOCnqk4O1ieUDCyrh/20dzZxSpr0SfyRrSUUbxS7cA2BfqCgNN8y21f2Se9CxdHsfSQ3UhQhddTG9+b18RmvMLck4flyj9wDAzEtsvQ="
     },
     "output" : {
-      "signature" : "29735383-62228959"
+      "signature" : "5994578-1468846"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "7",
-      "counterData" : "gfhFhs5orzefT45U1vUHOw==",
-      "data" : "uH8dkD3OC6Py5fv2vw=="
+      "counterData" : "pNg/hMYC1w/+tt8/Voxl8A==",
+      "data" : "3kF8kdrynfcB+CjsFGROg2LC0p+1ni4MpGSJfTi2ykOWRNeuQkpywnbzWHKusPsejfFDWKwMoBzuhjplD6WHweco3KHzCQ5OAqOgUe3uZ4ZEZQsKuq4oQ+igj+EPC9tNgD95dJNuUvQqUBm5UAtIigLm08vcvDQxdaUL0AEAifBLEHBI53LYA3mwWgBSxyZTZFOHp9S2681n7VIycqca0ROPSTkn7PiXIqnX+dDyg8EO244STOwaJTRl/ZlS9BA="
     },
     "output" : {
-      "signature" : "56977620-01106395"
+      "signature" : "8198144-4576957"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "7",
-      "counterData" : "Lmz9uhQDbqx/gCi3cKJauw==",
-      "data" : "wBAOAToWB6b89frAU0NdWAcB7glpM5Ldeh2AWZjDCFBrD0yyGwSD4X79+EsmElnM/ajlEvSMAcqV6A1u3u3d1AyuhbZu3WCAOrCjr6fGPais7xAHHNNOJQoJ4K4X8z7hyeZDqtOqB7EjUNj4fRFqoTIilJukQhF+u1RlghDpnlqBzbA/Wkmt+5kR58SdlSW/L8nL/iGZn9tpDPZTmR3iloUnjNKEHRWaTDTguljg7oKoLyteeAE93qFeA4fE"
+      "counterData" : "viSPctpEatJP2U5T91rkNw==",
+      "data" : "xeMQxawhE8wC9fIgygIasiABn8aK6NSaRgRAeDs24eTbbElBpTW7rwj+xf/CA4ygVc/F9cXoATFwdh7syMzqo2jCOJK1IX3w3w59p2Hc3UHDIu2yTaSddvDVaBiC7eg/lVlYAgk7U/oDRSw/nn8OTJ9SggsesoqoTsrcSqCeZMFjY2iapN+hOPWQmvGebuAowziw6SXXJYdSxgSZhgAyM9wRjlCXhVPxoSk="
     },
     "output" : {
-      "signature" : "52379417-00246459"
+      "signature" : "5562290-8604747"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "7",
-      "counterData" : "5h+io0oHqQBE/5O+PhwPsQ==",
-      "data" : "6cehpuFhR0BoyEi2nVk+NdN0PksrnmVj3l90cj/3+YqeNwS5akvNcmTRvfbdMdLN8+IkBd28zbyg+aL3Ar5GGzIWFz4gx9eZiQev0y0fQmSr72HDA81ACkHN8XaGv5qfqSmDX4AhodAcVDBPt0714PFUOwulNKBGhvH6pK4WfSYz0OEjwFp5bTMtZ1sjHYg/Pe+W+uT7PtlQG7T3TbWRYjXbEEChUHldtFYO6+i2EXN9zIrF0D/4LXMge0uWJPs21hC00WATdeNpDn8B"
+      "counterData" : "8/hACgLZk0L2jjQk6zXA9g==",
+      "data" : "kepZ42fs0BqY/CjnMkSe8JgVP1tjM+htErJrll8SsZukkQBeg3pUdWzoANlQQhviIBpS58yLyI8CSBOOHFamvcADZsk0yBuFlrRO8JVAcFfyqxY4tmUDNTj/SqjE4X9wManZqt1TpFIuhxB4q7efAP/NnQys3RF6SAHdNWYACRrhMFNjcNhEd/lbvO9S8Zd4juqVuo2Xh14kD2Ebju/m18EMhmqWq6wwFRZkA3txHHr5sSY0UrZt0D9kpe3ROuhzczlx"
     },
     "output" : {
-      "signature" : "24362916-25869424"
+      "signature" : "3145939-7721492"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "7",
-      "counterData" : "RrEKY8f13ZpOWpYdV9sPDg==",
-      "data" : "/TodZUZa6ishzZNc0QDiQqU0stVn2LAuboG7nv9HFvSJLwFO0LD/Rop4j1G8KQKUlV1qG9SQtHzHcCaq/BWJFURDYAp/yKwaqvukaeunB7VyQm8wvNcZ69asgjAxlM+GiP/PK4VxlE7QqnwTUg+DmURorZiO/jhwV6x3k94BY/OLtSUVHzeLjgUDk9pQZQNz5CfAow=="
+      "counterData" : "nJY97jk8DlR+AtKIEHCbPQ==",
+      "data" : "MEUrWLt4RhjUo2RU9TqOhsDop88ZPlMrVwSU275ihS/jeBvYB8FJZbK319dad+2e7tEqWnhtMA0W1NgqlIMBL6dS3N5A9YXIPqMUsgy6Ff3xuZMnt4BSVORUl7WMxgc0ZNDExmtdCw050c9K2SzTO5AOr4ZBNs9RNcsnr7gbGXoNHCL4mq8OM2AcHGaRD8viWFazDLzN/lFymJEg/3sw/7C3swB//Avygqs="
     },
     "output" : {
-      "signature" : "21619622-25623393"
+      "signature" : "8675710-4255974"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "7",
-      "counterData" : "JKXE9E1LO9EST6l3Alz7rQ==",
-      "data" : "AEsPhMioc+jZdEtLgB2CipdDMKWygCLjLimopjFXGUW1Sb4jXye9dt5fglZXLbvzQ4My5Rhq8HpaVjIySfTQJquMW09cw3lawwUvrz98GMuQCHeO+gScAp60XRE6yTD+T0fqvCtWoBHCNrSAusHi5s8ts5Y8r81NihlEC4aO6m+rmcMnw+jiwKl4p3YST9CP+e0GmVgIJQcxdKA2bbgCufM0lbIjbwwrX02jRF7exHt59OP8w1UkJmM6PNN1O2rjTrnSHrdRo6rnrvw9GfOAHrRctUuT6g=="
+      "counterData" : "ybHKINh3mzXweG4RMEYNXw==",
+      "data" : "r2K15tt2NcQ+w+dBRmbJ+1WHt2clMyGxx3fCnLPqiHifbrpX4e+J/EE/pLvya1hK4hHx3TMM0Rl0IbY/ZXaXtpwOnDjWHK9TlrLF1djjAGk31EL3BdB08AAGcJy45WYyRatOmUUWco+sTCeIXDGLqM6gpozOASJ8aiBbvUXmbe0SzlaOMG/BFdY1jaRW6uSfq+gthyz5NND9BeBEu/Imq29RyEYx7by0UhYZqmuWl1kfgCcDljqObF+3fsGvBSbfMScsXjG4XcejN8wWuNebrMaF8KRRwi84itKcA8q056EK"
     },
     "output" : {
-      "signature" : "50342723-05813674"
+      "signature" : "3027960-5781616"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "7",
-      "counterData" : "87ijtOAa2SUXBLKRMmeHHw==",
-      "data" : "8c2cNoLSXcCCvofrq/X7vG7h2ZVaaMu08+4GIVE6wnmVmsMfj5XLpbSf+Wj659kpAxVl0AQ="
+      "counterData" : "23XMroVrSPFJxjwurc5Vtg==",
+      "data" : "VgGw4ADQjG41lbH65x49P3AgiZNs0tguHMI2WGD2lPYRoi72dtR5Y0WqJqfgNCDAmyirjMsgu1oy0BaMx+DmzZWfDdvriKMlkdQq33EUPAlorH+XwfaqtH+/Q1ZDCsiqSNH0LEio4tc8prIwgUoOCLQDaSLQ2Sd3oRZsC43HB/x/iglp129efbWM0mwKTauWWU955PKN"
     },
     "output" : {
-      "signature" : "45568060-95226359"
+      "signature" : "3617728-2876557"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "VCJCFexFP/JurH2HloRQHg==",
-      "signatureKnowledgeKey" : "c+lG/qxB4fGMQBttfrgLSQ==",
-      "signatureBiometryKey" : "GglHlZPpA74SdbvLlM/Pgw==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "7",
-      "counterData" : "FwCmjE7Rh4gqBKsLcLWv0Q==",
-      "data" : "fUmZg2WldheI9DUUIxUdl0xR2c7HDr2XXu7E6ALzAHvQQpvHnHNq159WKmNkLjbKl/syYS2d8sMoAb5jxPDERy3ghBYcoS+CD9/2gwInR/MPHAobj797f8Q7AEhBgGT5hVrrdUDQjxOinvbICEZa+Z3jVQRdZL1AEcsrl5PB548fP07doc6nDZZhBHMZF5a8GYF4aS3IKv/kf7zjggZPADdChDSGfDzusdPNMKN5DdxbOqt55G4F+MPKVq5/PqDaNMs32Z8kwH47urIN0Ee4VSJ023LihyjLYoqZ9sB6vqY="
+      "counterData" : "NeteCoDkqbE0RQHO5RST6A==",
+      "data" : "GG90gQGXJCXJ5YwY0hsXpq5QLDCjfOeRoQ=="
     },
     "output" : {
-      "signature" : "21156578-82626229"
+      "signature" : "4788709-1501963"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "7",
+      "counterData" : "E+awHM/NsS27LW7RW9Mhgw==",
+      "data" : "oLRYW/PJ+w+u2CQ3zFxaGHF6DRBMVxqXYj3FULYwcOlGBOuC9lk1RTbVAt7X3a+TjeF/E8A5Gu30EappwL5ROF/yLevgecG7XTOBP8/WUd2HhJPiKB3ynvvHplm24e37cRfQoOndyn3ZIC/39JMalN+SYMyYiW9/Dx/+XUbSZZTs2ogoFm4x+Fbm2BPYn7xxidVs6VdRLER4UiPn"
+    },
+    "output" : {
+      "signature" : "8656816"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "7",
+      "counterData" : "zXBx6CKr5n0jjO+JAzqhnA==",
+      "data" : "m0OK4vsGpFFF2GY0Xj4vEQ+Glc2TnSWwSP/Hpg=="
+    },
+    "output" : {
+      "signature" : "3266715"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "7",
+      "counterData" : "eB18io4sU9Mx/OFO/9EOaw==",
+      "data" : "pAJu36WOteiWrNLoZpp87HE8whEvvwX8oOVQeWz26EIP9+UF0oAh"
+    },
+    "output" : {
+      "signature" : "5510979"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "7",
+      "counterData" : "VILTn9ltOldMCLhv97aCzw==",
+      "data" : "FEIZ8t33yGMlpXbnc0F8w38/oXb1NwAyFxWlOyRiv3wYTW8RVqxINO84RgbKz6oxZmukEwlBcodJV6LLflzgsFb2UUgt82P6NmciuL8FTioDm5LnRzF+o5hLj3gw2qt501489DGXEriF745KaNhUKFPi8XikNYSrhE9aXZUEsDuKvzkpIshzH78IA0+sUdVHGwTQIKm7haV87iMjF7PpGzJcHiYgVJQjshHWYXKTkyBDmRHSQ9SYiMLbqC1wqEDixZGuO77F/pbrCW7FuNdkjIVFgx6EBtKG62FKqjqaRZ0YB5RJQiHzthgA7VH3tA=="
+    },
+    "output" : {
+      "signature" : "0732634"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "7",
+      "counterData" : "59p31RcfewzEqLLq3IwB4A==",
+      "data" : "20WPg4J2AHjUzNjzPJIPrmxedhxfDF0BqiaLlk/VVL5mDWchpwBRnioMakbc+LUp9i+cQQ8sEEp8msYkt2+hFX2CXNXRgeY2uXDxe009Wl4UaYYLY2ziOCVcGP3fme8uBGUdlmJfcOoragRDZw0rN3nA"
+    },
+    "output" : {
+      "signature" : "2043464"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "7",
+      "counterData" : "EtCrY4qJDJbyKgbS0sYK6g==",
+      "data" : "htF0/sUGYQqbUOpwKPyr6qrebOcthuYeZ2wmCE+Xg+ZTAWM6M7g9g7zukVwcpGqv9/gMfH5ePd4GNNdZJxhGVRZPMyu122P4aurjIGcj80CsWth6Np/rZOSWxx407dhDR9AKfpVKpu8sCwTy0PhxVJDYzGP26PyzsYhqceajdf78jgwzPx9Kp+WJJaWQk6kKvlgEKER9RZPCocmU3lJGxdjBdwDHqZRdXQWjkKGV4RRfvcnWqPVFSQdpiIN9sV7MyB27y0EYXjz/+khFpjZtw9tp3mdiIcW7UMZDvf9sQ3u8hiK0OZD4eZzgM1Q="
+    },
+    "output" : {
+      "signature" : "0174976"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "7",
+      "counterData" : "+RvUzU6J9Mr0Kq4wT3Wu1g==",
+      "data" : "rHLPpGgqSh0m+LbUFwY2fRfU6ZQMQ7LR6oyfuX72qP7CTb6gVbIHetv3v8rf/F0TtOsvHk5j9NLbNBuyyy1sEgseAzvZIonlewX2+VVGW7QmPGb44Q9lPM+xhMYP7c9RcOfHJZEzrAtBuK0OhDpUZ4xiSw=="
+    },
+    "output" : {
+      "signature" : "4406814"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "7",
+      "counterData" : "Bat6pYdYwPxWgonFNFQtcg==",
+      "data" : "0R4hSPEvDAeggXLyQ/Vvinz0meRyehOMdW1QXGHSJjXH8ME9CyRtyMsn/d6qf5FqtMVCrtfH7PqVhaKO/5ICAY/y1dX8gyMIMxbB/D1iGkTkAaFI+ivGPZIGO3emOo4="
+    },
+    "output" : {
+      "signature" : "5775127"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "7",
+      "counterData" : "W0khudUCrLDY7AnzRr31cQ==",
+      "data" : "MXIsu433jTVIvmDifQL5tg8EH0gxANwKbaLKRCAc1q2xYMZT8CpfCItfJy9QL8IwdoKNb9DM0MXcVC6BPFLHgoji9aPhjdjGnXCssP/pDz32Qi6iuQvVRJmVia3xeeFq1fK1isC2+bVR3mKZiFvOXtKyGuWVaVg9+gR2JZHpMLEFunGMKZ1plS+joJ7ycMhSA1j15C0gkWd56S7yC6HVJDSgJdgPn/7mUREPAfNZx4hOWg1ognBd+ZAtAMO3b5B0Mt8xgWnJ79n39SfopeNA2ltN38bK92AuZZ3NDzkBtZBS3S9t8AHvW7M13d18OfgbaQolTXP6i/+y"
+    },
+    "output" : {
+      "signature" : "7948637"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession",
+      "signatureComponentLength" : "7",
+      "counterData" : "KjvTAzPvKipFGBv3vWe3Tg==",
+      "data" : "YLsJ0yfEl7o0wnESjpdTiBzSalat6NMk4vOKvrn5NfaR2iSiUaLDeFPjm5EowoW2f8JkUxLu4XyTvSMaSZGo1ddlA4XSNKqkr5z92ORNcJKIMbKt2YQCfWnmhIA1LsUI5j7e+CxhoY0DfMtboaZo"
+    },
+    "output" : {
+      "signature" : "4497119"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "7",
+      "counterData" : "TPc4DfIa8PA3yjtEh2Okww==",
+      "data" : "Z+uGpF8XnpgPGaLmpeucdOPm2Lw/kOpxsXlAx9wXbZEDhxuDGI9CTitf+67FpPeKOqjjmda7FAxiPtXhM9im"
+    },
+    "output" : {
+      "signature" : "6006085-8006645"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "7",
+      "counterData" : "P6m2dVD1BfS4r81HSZSELQ==",
+      "data" : "Niggc/jzxSbYt6jOfw+r2ZUBPHhUlGyynWwqm3qudeiU82Z4BXCe2CEbxOlM0UbWUtpnTL6R4tmph1mCx2IQtpASB6Donx37TdXUrc2BcFLrVVGhzdA0153cTqMyu6erI6UJFLuidJaa2GC/h40lkiHZJ4Jef/Vt5MWxxvwBG/CxMoXvBTarzA9el5Qnf1aHZ4cNZs0IDDxriV143Hti8ALxfi4J5VCYmJFJ0LYmSnSh8gcEeWXUJ0SSQ1qiKHBHmfgPzOKo8xU="
+    },
+    "output" : {
+      "signature" : "7070765-0549432"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "7",
+      "counterData" : "+fwBRBX7a0AHE7Anki0Pcw==",
+      "data" : "loYXweuml+bCMa8EGw4vLk/WHT8Q5/824U6Du7sYmzgmWB9cTgfgJMqehNkJjT/ZbU4IomPd4HUNEmc49eacVvmBRThpdrmo/mR+BPW/yrA2m87s2zUN1EUc1lwdE9ZFeDcTQ3ZeX6yM1uDeYfvoEPCgYPyUmzZbC67JffkncARq5qo/6YqIdjAGRN6xvELJunvjyWQ0mCNpdWZzbSIj2NvmHYdTc6M++8IucThPzA=="
+    },
+    "output" : {
+      "signature" : "4562764-9995925"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "7",
+      "counterData" : "C+9Z9HiVxIop67xDVtGnpg==",
+      "data" : "GIZFyOwvYzXZA646Lt3W+UDFIwTacv4RFLlk7a7uVH+rVlYH2GLXAMC+1n3rm0JS/wZ1V/wf6hDdqnUBA8lpg44KnPtTUgpT2XZiDAVcxnGmPkgG6Fg00qSCG3A0px7+ZUCmvKmgdIsQrZGkPuaIqS15t+eH3A=="
+    },
+    "output" : {
+      "signature" : "1871839-2981015"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "7",
+      "counterData" : "ji63iVg1cqM68m73zPGU0g==",
+      "data" : "JAJBDyi5ByIjVSPZU7Tb2J+xzNrthUpIpruQ76Ths7dQSqAUOoQdFAcGqW/cv4BmnSuKNWPo/RAC70o8G5iGdCtCl00N5JVSquiTi1pwDj6+2T8PG1abs2j8NBMpsEJ7JAVJGI/2MQkF6zg1x8udnSCNoVo7nR77DdT6WyMy2+NqaYiQESkDidh/AMluHwZJsbXcrf2xPT40u9ADXlYate2Dkw0acv+pZvFXI5CZk3KnH2zjB4oSyoiRmhv0+w=="
+    },
+    "output" : {
+      "signature" : "6789117-7845049"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "7",
+      "counterData" : "Mvw0/Dyup6s4Tl2T8YttCg==",
+      "data" : "QUhd7lGKKrpxsQWgBF7eZoO1xkc+BKs8/2dT+UXWMoegQzSPWEkZCIzsH2RFTveRUmzOLDljvceyecQWWJYUGzjtgzWuJoMUaeplwLuU++ZyffnXj5OAaFzrnjvgOcWJGiiU+dp7rD3sxKgdQ2+sYQdlUcihMKGle3BZ5wZXrt9Tw/4rvWOYlkc5XSh/bNcrZCwatpZGW9OQdkOmriJdPQsIp/iguKNH5kFyi9heodIwLTMaVeyG+frL7UvcBjlj4Cn9rThJ9oEMGZEQyQkedcqZF67ooQ=="
+    },
+    "output" : {
+      "signature" : "7138043-8183935"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "7",
+      "counterData" : "MTPEW/hYm+rBOSEM1a1LZQ==",
+      "data" : "2SeZTatiWIEjeKnAOhnYpy45PRYCNexUvxliB8yyn6816v4SN3IwhhIdnpG4eNjQUpwl/IXELWpRbt0sPwYwRAEVHEjDmq4Ve2uuON3eGyBDo+AgHG3ZkWRJ+EQju1UdCDlL2HK/9TltxkKhrrmfUOq1l/o+0pkWhSmresJTTcmDRAeQCL1JcFCIP1D1QEi7WAyCYLmwGimfL3u4HDQQ9Yjs93mNExA0wu8hz6l8JbctBcPwBOBVb3M1tH2FOmj5uf53JqqKuJcfCw=="
+    },
+    "output" : {
+      "signature" : "9923803-2392272"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "7",
+      "counterData" : "ZhY7jEn4mHprdgxGSMmTNQ==",
+      "data" : "bxUk9sx2Ah04ycr5eoACpEvQkSM/LIgXSwOFP6P5zvHbhsTG5Jxo+rDt8qPVOewoHIPG4qyeIAQrv3NYMn70XzxgJpJx5nT50+EPU7z62IwdvcwMi+Z4ry7uqgulbWa1sEmHfXSD9Tt/aWxHm+CPFpI1jpv8sdlcL9DBO849KEhNlNI8m2la+zp9oW8dOG65d68m0H3TKFDtEtqrsDH5kp32ZZgwnbspwuNCNfDt4ZaApCPMjRXEb2NW6mfy64oPIajdbUowtmdqBhInUGmnPvR7pl6369c4MiPFILdt/bWznnjQyrAz0nCFKg=="
+    },
+    "output" : {
+      "signature" : "2821565-8897506"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "7",
+      "counterData" : "Z6kFBnfhvMSrGkOCAPhCZw==",
+      "data" : "glRL9+cVW8evWC7n+fDb6p9vEbpeJIONHyFARSJUQae1d2h3Q5nJ9XgzqeipC3TSLTKv/LNd7u3TMjotAmsAmUUtJI6Eut8yHxh1AjwQgTuyMhDT25+QwrQW+sUs7B4mQAFQzmtAwClqtlM3uNacbV4MZk7+azGSrH9p"
+    },
+    "output" : {
+      "signature" : "2348069-7076811"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "hEMhLMIfDvfljXbV/gkOgw==",
+      "signatureKnowledgeKey" : "eT1Ip+Ein10pFZ/ulcY7jw==",
+      "signatureBiometryKey" : "ufJMzVHfvxDMKauPVAxILg==",
+      "signatureType" : "possession_knowledge",
+      "signatureComponentLength" : "7",
+      "counterData" : "wDLeDyNRuDkMvACEA2zPHg==",
+      "data" : "ewMcs3cFfCEJ3INcJe+LH8AQ3trnq1t4/PvdQD5W7YBAHLQg7y0S8g3OYo57rwl8Rt73Al4od4Llf1Sst6UW1jiH6mRQcwBcMzVAHwdEGure5aGsaztZKgKIMFfLhFEhOHqABw=="
+    },
+    "output" : {
+      "signature" : "8753590-6557008"
+    }
+  }, {
+    "input" : {
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "B4mA2aNMqDuUX/WAvWpLEw==",
-      "data" : "a0W96KU1vyGPxmSCPexsKrog1XH9ZAPtL2N/mlbg9jOZNgktkBa0G4M="
+      "counterData" : "cnwVbCA6LyvzKyxYyOofhg==",
+      "data" : "7OzgBTYIDjpzb02NR6vdW5FyJqZuKSOwjn8UJls+HoAf5mDzmclxZ8WEhPTnfOu8wIJVQXwHgDbQ490AXj/RM6Fe4Og0EpFGi72GmOh+3j7O2u1mNMd0NCppm0XlFL6LVWXFI3XQ0SOKGE/eLQE9AkfCwRrm4zjjGvQMIBhWqL6IakK2GcpAvQ=="
     },
     "output" : {
-      "signature" : "97297134"
+      "signature" : "89903407"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "kAkAlRNOfhVHwYHJzebt0A==",
-      "data" : "REHxUQlesdAYjca3zEOPo/y7hn2NHkZzU2U2PQzZpoTD1a+brM32YrUjUa73BrwIo8VgInp0Y8Rg2yP1LzxoQ3JGskKEqgrx8gRWte7cU47DW1kvxv2TxnB4ixv9qY19pfQoWWnKvRkBn85wjsUAsJ9xOegf+Sg0etD6JnnTCHLRhOvd3qrDty82AcTuhQYhikvwh+Wv7wha1AnwlWRXKkXlMQ=="
+      "counterData" : "xYAnExCKM1UTSB9ScuZZYA==",
+      "data" : "dXo2WbIwPWMAFdbcxfk4vewUqL4r0eTdgqQ="
     },
     "output" : {
-      "signature" : "73598081"
+      "signature" : "38298088"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "xXiK1igVpQLhCaZF/RyEQw==",
-      "data" : "yv/YFov3AwD+CeMoUCFL8cje+dmdmvYW0UsM3bz8R77Cghh5QQ4VoAKfRS7FXGKtfVxIrU5NRKCKb2catnY+WGX/WPKxk4kaVYKzeWAqa07rUpUuL0PFaDlMUjpJwjZz+Zhzh7t97KdkNqZGwEs+0gJFMoPfEU0zVcTNDOQpF9g942PCts91sjQO8/5e/MazMkFd/RfYyKE9HO1UXgRO40fSWlFhA0iwJvEG+SakeaqLJuamOJEtXAopE3c1F4xwBUA/H8uApxteYQd0AHuMExKTvge4FQ=="
+      "counterData" : "OydnpA0zudTqYMgIf/gkjA==",
+      "data" : "lAf3mdKSdflR2LH7R3n6FHTxQkT2QEafhtLzN1eoi3rBRPg5b1YgfugYB26R/6Ej43odtb/oLlJ885frUb+zXFLs7D4uSlthhVFmDp/JxA=="
     },
     "output" : {
-      "signature" : "02331780"
+      "signature" : "61462659"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "sElJrKiwfqhR25279V39QA==",
-      "data" : "+S9l1dsqBftkTuNRsW3AZ+lzOrROvEQXF0zay7NmyDfkTW6k//MjGOjlGNm/cr1DkjJ1bD9i/J2vZYchDLhdLfsb1cyFNhxZfinZhXL4l//F57w8nea1W7/NG4YHzeyUQRX62SjNwtW+duMV+wJq6jcJe0ActsTGbXBOiNVnHEFxkUQVsRnVKWMMLi+05ZmjepZ2BLZ5juylS9qbYyrOz747ZTTBx1g3+ys4nJy001vuWFC4AAmZaNSeHdaLrwynOtOvMvSCfh1L0RRvFJulxZCR6tyhOMTeJ3Gv9po="
+      "counterData" : "M0gr+ec8IDcWvo6tA2ScHg==",
+      "data" : "uQ3LewlC03f3HDZDPFoSdObvlYcJhJa8LE4sTp33Y4kQWJoWuovoOcz6ENwVZB/dTrxV3DcDkXTXiePSX/Y8KoTtOuTY4un/4myXX0xcJ8c8/4xmK+GF1crL5BE10PrJWOlqx+3E3QQUqnOC8U0ILCSbRV6Ulut2Aewpb1lFLXUsaoQiruyD3jfqu3rj66jdoTVmgA=="
     },
     "output" : {
-      "signature" : "16061801"
+      "signature" : "10126936"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "xjIkIajTBhkhePac9Aqnuw==",
-      "data" : "3IuhPrunzw8azAFNKKyQDN/xVaG7aThq1bPcDD3jnhO/etVfLKXwQSuyxbIh2MzaVv4uFXUDYox2aaJVzLhraooge+cGMPp5tLCCEuDZeqWftchc3zKBd+pEQdsxeZ7DSvCScw=="
+      "counterData" : "tqIiJ/mZ+frWA4E0NdYDvw==",
+      "data" : "C2U+4H2A2urTYM4UCrMJM2nj+KuKacPGRN77+XWVcZnx8+FPWnm642sTcC4djOVl/QdOVaLKnDkbxpPDx1Aux3Sj9n4vqN0ICs8NXcjsbpr9GenxMT/yME5jrNMEgmGhMezxdQ=="
     },
     "output" : {
-      "signature" : "33256825"
+      "signature" : "68428587"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "zJcgOzCGtIGodJfXzjofrA==",
-      "data" : "jwlrlD7bFefndfTbBtRjtaCqjnsjSQciXTmdnMXSooDTJwG6mZm6t7ZKXYCUERX1KJxsu0qrzzbN9vDgcYQhKc2RLnxm6rJsSQdKZPTPnkNweK48sAxkEBMoCP0lA8reaKZQ03z1PFzaLBb/BRmOrqsNCsgMUEfDsdc3LDl+/goU5ejEEXgg17gbfdlneeCO4A49kTsPBwhuEfa57ItrjOPWZS7nNnEFLJeLkgSLyqcxteNFUUTgFuzd92/KDVS6V6/IswiRkM33iQcJ+AcIXAaYSZv7nlBnMc0ulVE4eAPrF/bUsw=="
+      "counterData" : "OJdLMhEmtyCt7kZSwjAwsA==",
+      "data" : "jqWCOa7b+iYUQJvl+dZur3calCqwYSytvbyNARQHgHk="
     },
     "output" : {
-      "signature" : "15003236"
+      "signature" : "58486519"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "+MJ8p7bInHMOdE+W5PToUg==",
-      "data" : "zYB2/8z7GsbVKmSQgm3gZOhxpl7TLxAiXvIlJI8cxnecIs7tWGqRmzfotB4C9Wa1xIGJytar4h8mpS8JOwCaz9sSheucv7HmhMnzIIRfdwYbSQ2aR4VqxsxGe7y6V/FcRULAr7wkL8ZcFX+FpZs2lpSweBErQrBIY9aK4OqiLo1kO1Rl1E8lqp7Ppi93mCR2cpa6gjw/lYPPLZCt8ILd0WAS2SomU6oV17beLHW7TBF4A03mUv1kWg=="
+      "counterData" : "1jrhgHv0YRsR9R7RyGcMmw==",
+      "data" : "t5whSuPSSERmHCHujt+bIdBih1P7+/9HS195jooo01GQEEQ4ooOnvOzFBGgcR8k4MKQnLFzUL9R2jpKd1SW0yq+D88/AQWKfA22cgiQvS26SHoCRfBx9ZH9Ka7qol8XDaU2pXdhJxdueAvql2vD48tSjGq9ZtT42FOKyTowLQjY8giDut11D3/1G"
     },
     "output" : {
-      "signature" : "66400528"
+      "signature" : "60925974"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "s6/VxnNvTLGPV6EK3ezPFg==",
-      "data" : "LnOLrgAXV3qvoopoKzh0C+/U+Lm8aPNYY0Ua9JHITTYZfxtdq+2ReA5RDx/SuFeIKqEvpNSUDAZUwU8C96trhRCCisujxmHgbViBJ3GGul1cm5dfVK0mCw1LgtqPh3vaqstCAH6f"
+      "counterData" : "nxyQULvjTlP+OpAxmsCIAQ==",
+      "data" : "3MOjvrRxPfSqcs0fXRwMG5NXEdOzn/rG+zshuurANuUJ+ux8lcEFEdTlbPYxbTFy8V2yhJnT+3X4fzZUEoXPnTyNlUQez7nzZw=="
     },
     "output" : {
-      "signature" : "47141719"
+      "signature" : "10288101"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "agjEiYbB4p3B4su6PmrArQ==",
-      "data" : "dM3r15gPvUFe97bsLZU1+eiI6OApcT5+V08="
+      "counterData" : "rpn5o9pjZwB9Y0Ak9jd+JA==",
+      "data" : "RfAbQMecfsroKslBb/0KapENyGvpDug6rmKDC+c238Ek4HMZCWsyOSY5m7hO3aEVdOQhYABIHz36RRfD7usnZJbT/XH03RopOJ+cfgD0bFkZggLeFh8QHHOrqwprAkB8xVtmmkNyxGfP10CJR4xLryBkXUtNqd5WTTZP2hFARoI3RGMlVlOrzQPo1D1I0dcPwtje6h9cOyI="
     },
     "output" : {
-      "signature" : "71009758"
+      "signature" : "61366891"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "Jn3Ao0Mik5Gn6XQNxet7RQ==",
-      "data" : "tzWUtnSYoEJErZ1KEMZhDnIi/ZyezXxFygsJNX0vMqxGqcLoAOsZR/uQcFDnip3FNpfLwyQfVXSObK5vthSsoHs13krgnCwp8eSdDEXuitDUBrCXANs="
+      "counterData" : "fmK/dU8EVLWSEeWqwi2WJA==",
+      "data" : "ZmIqpXpkNwXec6UfWaesQkVRksU5+Q1/4MmekiFN/pLy5IowruJzuuvpKRAYSLVh5ppuFTWQVaxSAi/PPEvgnUWTjHeNfJ76ISe0mWaegTlGpxbvBW5sdXpXBIAcLibPaUgpYBFMDQ2JmNB2AqeauC8fSaN6FBfuFhc+dZc8vVuA5VJyknCoPmaNUA=="
     },
     "output" : {
-      "signature" : "01913136"
+      "signature" : "53825511"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "zl78Qh368UCKM3VWqXgqVQ==",
-      "data" : "ZCJz72AblVfSNrZPJFB9BQYR8sGzGuB4dS8XgfGexHFxfMrJnysptqe2a+I8BW0I4g0E/ut2H4CLEGzbhVukkRwMYZ5GXFG8b8osZomM4C36vZ0pIamyHJsY0lJ7WYja0Tg1DNOtV5r+yTUwPvnAsM7PJyC5LOCuS7DKB5jDyCfNlQC5i4WT/tY3ZA=="
+      "counterData" : "yDu9Bg8gnsAufMf/sxKbaQ==",
+      "data" : "nnkBeoUyrD4l9t/05Op8dERhWdMKKLc7LGJD3yAW5WOpjskWn4tN6wMN3JpnXJ9zYBdKtWIS6mkWZgJf+gDgfLLj0+kFlCMGsdmZgdlqkGQyJ1ya34BKAAuACTSrOqpc4HBe7581T9LxFi1SJ1OGEtF/zBEUOC1RydR276J9LWWCqHHabejBqNNkYE4KtcxxN75Fz8u+9jyjQiDF/uElqy2tGiCLNkIErIlyVsYajTzhQMeNWvlHVRTyu0h+9tAiCAITcdicmFIpaV2vyM1DQ32Ixq4="
     },
     "output" : {
-      "signature" : "17601293-25606715"
+      "signature" : "70124929-77581099"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "7g84mh7vUFE1PkSC2QN0Cw==",
-      "data" : "EboBmV52V4r5pjuIMzD+vwbznwBRQBt7VZDhE5xwr1hJe+uH2KpfcCMXTVz9dSHjdmACYCpQwtoCCTVwQe8A6XCR8azsKEeJNBKwbXHR7/4S6Jci71CEtQYUFCbwixZFKaL1MkGjEyrxtERb1c2pQF6SvMn4p7VGOMOKLxqOT7v48QZ4p+WjJSFIc5qovvpXP6Z2Y8c2HABJf/fxZ+9mHbXytdURttTwPjruaDWi+/z4Tj1AvxsQNr9ZX8+JyCq8ZGUMqlgVTQ=="
+      "counterData" : "4Y8GThCiW0tIFkRll3X+Og==",
+      "data" : "yg3l5ihP96uiqB7+970JlPk5QbndzSKgj3ZYZLqWeCgxaKu4F4DxRezY3lpiPPwFgl/noZmNIDjinVI1p+8afcSe"
     },
     "output" : {
-      "signature" : "22742429-98723063"
+      "signature" : "99612817-65237359"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "JDTjubZsXnyqmmPzRAyrfA==",
-      "data" : "pd5oQjhZW6YVNyDcZ/e+a7h8ktxheMY42AIjRgOK/gihlQruigCkIRWBDuXL5ZMVH4+LyOFYSh+32pmwAxQEr8+aTDC4ECV1wJSHuMpq1sae9gjxwoMXeC0887dr14cX8S6R5NWxugTQJVPtCkQg5It45UgvaE0dlfTIyLJOxT7LZz2EUMKVPFQciUVbNhwrJA27rIQduKwZf4tCS7HHroYtcAc2LhogWLmnzG3qUi6QyT12bR8sXpChKjPcMGbblvZRRAEj7HRG"
+      "counterData" : "dfJm4PO8Wb9hB4mA0LlvYg==",
+      "data" : "/Mi34r9RD75aEadmbaB4f26o3ontuljwmhVjiKlvyt2xTFKbcWhX9GQEnmYKU21KENgD2s+9fpbHZNStpRv3mu3Z71TSrLTan8votOUxw79rpUsEcoaWygUfY9zLB3n6pvHCOYI0/uwJcGrL2biX546XIR7Zh7mWJ7ndhCvaj3bGlHWCK6q7QrXyuVdTV6W0BK498ixaKr2BpaKlvlmiuZy4KTcIdXnFEg4fT+wFEXA2I8VnlFaVHHNU"
     },
     "output" : {
-      "signature" : "11109006-96632668"
+      "signature" : "21201931-41820737"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "snM0o964NYuc7p7DrW+Z7Q==",
-      "data" : "xcnddbnNx+4a5S8ElvGGizBpTPQClIxGOwTHZSBPCxddSYecu8QNL/ee8fDCLK7fZA9OmdspUd8vbNhvYK50IQ1CLVnumtfXYHHMqJkQ+MaMF6I="
+      "counterData" : "lckZe2sDwJS6GTlHsslJ/g==",
+      "data" : "dwjIt9DABjHbdKAFRZcQHZr5ofLWF4MRo+vfWNQJWs5tDw=="
     },
     "output" : {
-      "signature" : "07273735-74049381"
+      "signature" : "27718674-28442310"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "4fnhVJEMMDHbdJXCOvrq3g==",
-      "data" : "7LPe5ZknViQHFZHH1K9VwYggh1h5xjo/jql0c/9K4SyUyyA8VrxsaOGelzI7+bAd83TKVBxyNKY+Uu8aUr9Ru3BO5ZEiSrk="
+      "counterData" : "2lH+swOX9wARk/WJv1tc4Q==",
+      "data" : "G7roR11TUgQkPnOScXvoe9mK2LonEPRDZNfA1xUMlcA="
     },
     "output" : {
-      "signature" : "81494642-85377064"
+      "signature" : "27614736-68929398"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "dKReDpEufH1mPa4+PuREcA==",
-      "data" : "9oVPhq0VXeI3gsJ3JencVKlvPUU7AWPzL7GFOMq7GPwRuVulyfi2jXAzbokIAtZZTXZLUgKWTXB6hkLy1l1nJHHKKEoaGj9K7wqCNa5azWBz0I/b"
+      "counterData" : "XSSOkS/CceSR9rkixoRUSQ==",
+      "data" : "LZyHaR/8TSlnNeUa2q0w9HgUDbveVB4rKkJxvXeiCaBuOAoHqmZl9iDKIHEEsfrlaKnOW8fJ4a/rog7TV8e12EUEpJ7yn6PJJTrJANYsDdwAuEkylcgkwAMb0b3v879/aoeUOypeDj3HGuESSQwoT+MOeqOhlkM6D81+iEag+nNt4ittsToz4/uLg/3xXIQ64+vhV0q8wc8XRAOnfL5VxP3YkvkvSfL/3TA2GCmC3Pvg55KL93Z54AYFcwTaLyoqzYEigXCzxd0nOSiZQr6I715DdRE+y8UHEk0TgBCYxDg="
     },
     "output" : {
-      "signature" : "29178762-65612080"
+      "signature" : "24109076-47670728"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "cQ0pCqBcHhqbVgIaKAqAVw==",
-      "data" : "zw5WsKnLRXiOiI2QlrBjzttdT1LPiniFq7WAaRzgpmyFOihZR1dscgcR3VImGEm7zG+yiFU9VqQwJ4ZL84u9Ja+JR38+sWfsl3s1pp7UPyETe7Y="
+      "counterData" : "E1K6cW0EzQFtLb/iwY5Sbg==",
+      "data" : "gErKvOC5laTC62EAF8iXhfYsJ5d6hHveCd5VEEiAQzhViZBLGHfD01xeBqwa6oKsTID0I4Cs0Gh+V7EPNMpk3SHxQmA4ZM7kctVZc5kHxDpvlza8aclb4HHJqluezoq70ekR7xB1HdRZ2voZ2O3yUQACfOMu5DZlHm6kJ0xrwluDnBXxxeFDvj0Uae2F0w=="
     },
     "output" : {
-      "signature" : "73355657-47256321"
+      "signature" : "23583056-08998295"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "sfb+kbcEiMLxLNpQS47EaA==",
-      "data" : "unwzyoPy/RJogIUwKlnFHcZtTfALoERoHnma4thUysLd3De/zoNGwAzyn/77vbT28LSYmZix0ResxtL/GeqNIYn+dTnMXmxbCii6eGyqjg48NEEkPoHcbalklY+k/HNehQlmzFYHKRLKd11WKIPE9x7Ys4Rb+ce9UcbjJKZDYWS6+8sX2eiHm/XM"
+      "counterData" : "bizPxl7Y8H2HceqbC4jskQ==",
+      "data" : "tGfhpI3NBD506ZY9yze6HcYtGUAw2NpwWSNHA2rQtNLp/tIuRAjHtvql21gRjHelkN3B4P4LmdrdiiDigJqW48sXaVLhXrLydJ5nnSQcLVUVpO0H+tv4JDyARz9isOIW+Qpdi73Kbz31iq0aX6LKO7CkcyYCCPV3w1CQ290="
     },
     "output" : {
-      "signature" : "46311690-20654056"
+      "signature" : "27138894-86812470"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "pyhBVdmHqBmwtjdGHViEtw==",
-      "data" : "cYBCT9JgAonVq1jl7KSUlVPy9wdBv9LDyZAawG3KPbDLswaS4rxKb1jSqCh/f1yPnWV6GVoWR77+dIFB/n9h4996OOxgI948WOysxt0b9OXyxvmwLU8ETgXLw7M4UiyYE/S0IX26DKjArHWXeQEPomtXHSiX"
+      "counterData" : "h+u5MCc03SY0LyS4n4Nxxw==",
+      "data" : "tKt4Q1t+PEhEKmXeRQRU6yPxpszDHoYp8HuBdZYqVBkPyf/CC0thPKtJhIJRkYPfnjsnDT+oJsm8fqRrK9B4kyk2kecM414BK75BbiVOV9C07MYf8rcSw9+4KKh2Cj/GXC83Q//Cpzj50nPrfD/073Bx+aJV6hWQ+NdMcQAA3jRRytCJlZ5R/vVV8/lMbpLo0Wbe5+T4myuan5OC3H8Zt/BbH6XADNUo7ala4d8x8Gc2ayuZX3L+XphcdGUYe7oM4LWe2ca/odO7P6XIneFtU0H/DSejZV2dRoCs9KfdF8kLn4qnOPohpwWalg=="
     },
     "output" : {
-      "signature" : "05728075-51694520"
+      "signature" : "82845340-14593341"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "mzrmnR4vij2Trk44zKuY2w==",
-      "data" : "fibwJg2lki3CgzkGuJMbp7znCEmUBw=="
+      "counterData" : "69P/b450QJvCMeXmr9OJnw==",
+      "data" : "0czm0sYfBQApYH3O8q35r8XIQaKEZjqD8a2imB4b+WtzU2AGFgQz9j764UWTj83iUA7Fdf0KH5KLJWqq0dj/pKGnYbn3LkE6Pu7ouTlirp/dQGuPAWCa/liC+aJJjyi5mgYXCUSVD7vZcItSDYtQdhYfQ7c9Lq1ei6XBQGhluv4UcvQuChP22syZDXSy4Vw9OYVut377FQnGu6sGW66F0wUz+3jXxmT/tKw+zRZ4G7JB2nvwPv0fIQYuCmCT19pBqzgu0xS++w=="
     },
     "output" : {
-      "signature" : "71650600-65268369"
+      "signature" : "12389443-99496946"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "VyIrPlIyLkQVUuqCjbjh+A==",
-      "data" : "9zr6Xm3gBQCmj2o5V5/f3y27hjEJa3rotknKFl8Qq76I4TcSofHezijXsa3iruFs6EdK3F7lhboiOJrrydOccGHltW9C1j4YH/Gw3UAxdjRNRXGjt4fR7mOtyMlrwtGIF/VnNEtkoKuYaBOIiI/Zw7e4HNdh1R7j/qg4x69HuV8m5j/FMFGAz3UIgkbDsgEXm9wUTaxx9mEkEKInyBcpNtSufSdbE/i09VZz65STk+dwmxFN"
+      "counterData" : "VAI4pWHVuJceX2P6y8ItDg==",
+      "data" : "+2PVJ8yz0niIHKBhLfONfqySyAR/CIvZPnL0U500MFS0LLU="
     },
     "output" : {
-      "signature" : "06606753"
+      "signature" : "18732978"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "HZbhy252H63lRsLqCWRxqA==",
-      "data" : "K1nFaapGqjDphn/adlv6foioJhCtRezhhL0p+G6HlYqvpq1+dZRW/DmmwaJwm/yv6L7KFEfAjYHEoxaziv2DognuOiBa/S68A4JHHLJkxWUbFVbfvosBGGqFBQaxVa33w/Bc7tnLomzfP1uzyy+wG8sD4qV19GWIYZHeD60Rp9/QsD/1IHUwEU6d0GHb2YFmUBTW8E2iV2wluh9eHcUTNaF2C+SMYklwJKR17DeaDCQcoa89yLdaJP5Tu2wAtkY="
+      "counterData" : "jOsPXHQcreXUPHmOAhjfUg==",
+      "data" : "L8nGjn3oKEg3PVpKMXuB+Q428vAHN0i/BoGK/+TO"
     },
     "output" : {
-      "signature" : "51859227"
+      "signature" : "77104720"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "+2ULbA01qnf2bVagSCS+Fg==",
-      "data" : "38w9vlCmJBaucbT40o5ZnLm0y+5g8cdoA0rI/EtOon8lvPDowVVl4OvO46mA1xJqmHu/Ij4CvcDLAG3n8HFrPHQjjtfkhrEw3wyyvA7Y2NbaIfvQ+MPxBWvzZ+WW6HJ3FzFsuY5hILfRJaIrUpF+hBhrSQei7lxeQ/sbovMkV412/Ru/7nkwFooGFF8aO74YAU5/xn858TAc3GVF2/OTubyh/BiN4zUOfXslCMVys3toL293Urp/gY01YHOdFEbQCD7ICfE1+kt2HB/xUA=="
+      "counterData" : "h1Vm/HOn4qMXcRdEB8yN+w==",
+      "data" : "9f6kFc2sOpxeKd45IDGEe4ZgaTbpRJ5i477v+D4K80dPcxiGnjYKDhktr8SmC74Il0BaXmdXsWorUoJyjcnFNpy23yxD1UqKhDCXO+dYIc9jbAYvQmOAslMDhzejhqOqiu3dJnYbdcvQxK/Le07ahmz3auw26IecVAAFVqDFspmy"
     },
     "output" : {
-      "signature" : "59785025"
+      "signature" : "21616113"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "us+U/mR0lrkA3MCokmBMSw==",
-      "data" : "gQYDYzi5Q+/1r8uh6Z3g+LzX0ZmPI20scmrOltTdqecScWCG3tj0PeKvzw=="
+      "counterData" : "iLu859qJOobWbGFx7OlrmQ==",
+      "data" : "ZCFqsKt8JSj6K8iTgVw/rPsEee52UVV6pxaK/YCS46u+GGsL6xPjQjjO1CXbTANryXpHbqC/7wKANja+WBDzjUdBcH1iA0/y4Mmg+z3uLMmAipBKK7RjhWPWyB78Ojls0ygbuC/4D1eSdRGTlZE="
     },
     "output" : {
-      "signature" : "59331228"
+      "signature" : "85177108"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "3HoZYqbqWbNFFx8+BFpsxg==",
-      "data" : "bjDR0oxqn9UY"
+      "counterData" : "FkycwFWegcjH3ZCLsjZZ3A==",
+      "data" : "mI34tJGcYJ0JU49+Pklkc4/FVDJNtY4z1wkBcE+FvVovpw3mOzICGjH+ik1urw=="
     },
     "output" : {
-      "signature" : "99223768"
+      "signature" : "66950544"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "4SwTVbQxhfnPWfZBt2JY4A==",
-      "data" : "zwp/FJjEAwq+XqO1uzJU3p86365EOU2MMfCFLea4Wtsm/TX+8SE1pY735NIj1VkEEyVk9g=="
+      "counterData" : "y8kk9IH221/qJQ+wcQaQpQ==",
+      "data" : "zF8W4bsTBdS4FBT6sacVtGrMS3JDaLlqHJqtuAYFgeECUtKq0RcTrXLeXERrknwOpxCYRhzemNdhw3E7dNnJA5GKic3dRo7s1OmaeSVjJSAMK3tL2bGoKXgvaVl2+3UMwjNXytrBVabzp3PAHECyZCWrCvxzQbfzMNNveSMQBsZ9ZU0u1wGwfw0crWI="
     },
     "output" : {
-      "signature" : "58976707"
+      "signature" : "14823399"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "fX6K+mZHdawWhu0bsPejHQ==",
-      "data" : "Lzh6laioj/buRlyuEc2Wk6Fed02qsvR9zgTGGcABuJaj7pydHKYE+5c6pZz+LPB1"
+      "counterData" : "cNaSj/EzkZki+menstsnlw==",
+      "data" : "Ld8WFYlsf4MK6wBqaeebRlFiKLLFiypbN7Bt7FBhso0pw8iAwqnXMVFOTjWk91dHjVjRHZqY/n2veIzJCZo5inX2DhEDENqeWhmU0JPAJkCM9MHoofi5"
     },
     "output" : {
-      "signature" : "19803491"
+      "signature" : "90396218"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "u+vXDD+5QZ9rdwT2f60CJg==",
-      "data" : "7pQ6DCquv4J2O1QwhYvgyJ2d6T1k86gB44OnFhKikaG4baoSynKzIO0wrYrRPA3QpKdgRD9crdOvAVlw3DOwOVcyZf6z2kRCK3yK9VoYWibCs2bbRHU7NLeLlGpPPQebe4yhYnZy7kgfyx3gk4BqQXq+pBIXM3BANLfaao+jyILABl/rqtc+m34/gjxpxnps+tm6eYyT7gba7s2jk4tlm+TPeQsWf4eMDkDDL/sNJkrsxMn88cdvbtqn1MzLAhqcwh9CJdZnyFl80mQ/qJ1k/Lhbs4J+dR8htSGq"
+      "counterData" : "CwjUDxi41CvDfedBKvcrSg==",
+      "data" : "Qo9UUkOhYialEPTjUvI9q9BoBJJbi0c+Uo9NJiD17sRfu/aRAXNqktkwRNVPfuGQDXDNmw+fxAUJIzoHlho3uK4zCzwI3QXfyDOZua/8mjGJDbEELdtBlLRWy2lggnBfVH3VzPUNUgGXUgotTMOKRleQ5m6YVtTabj0UH1DpOVzOsUBi6ALBOqAroUM9nQ+T8rob6qKw25pvIx/GmM6q88B9VIArsZUKs4kyfBmx3ngOt/4niX8leUvD4JzzZJA94vkZ4wTdu98e1wutMbCh9guu4AQiCVyeGzWEb9QQkDxArw8FZQzRcQ=="
     },
     "output" : {
-      "signature" : "51006105"
+      "signature" : "61113384"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "dqSTjIK2UZKtSCM2q+ycFA==",
-      "data" : "qclJt9b3B6fRX8gKHr4fjAhjGVako6rIbbKbatXPHvy7rF+XFoSNdJkHDvYpsVtQc/C+F2j7pPhLcCrzca7BGctAINNaDtRUH2/sc2cwLW9BnOk="
+      "counterData" : "OryP3x3iphPjQFL3HMiAlA==",
+      "data" : "RHH2oqJww7FJKu0p0zWjjb17cKNzpU3pZ/ushd/cuHgzYP1ATnmWqPbQ1DA="
     },
     "output" : {
-      "signature" : "85617230"
+      "signature" : "64439871"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession",
       "signatureComponentLength" : "8",
-      "counterData" : "clxUtUefSQKbn9Z7OSJYVQ==",
-      "data" : "UWK5AXGffP+C5kL/WA70JLitv2j0InpaHOOCkDqFCJ1ucTRaT+cGICS4eeaVKIkcZ3JKBPMOUVjNswEM1UCXDhou9G+24gASfz1GEk1IVlpXKOhJK2lLUNkRQ42yDNvgy+KpD8w+quUK7q1fBxP2cHy1vEayXTKOw8f+HhNSOWjEaMMjSa+ptcSV0qkUhRlntOaenkVMk3vtMVEjP6sMlEN8U84cMghA1yYXZ2BIEOBXtxyv5YV8gBy0oG6/DVJ42TN2eBqYeGPRYS20gNnkI2AE3eUNOs6s9EPj3VHKj+Mh0A=="
+      "counterData" : "Pw3FcFGLRmthoGgqIrd/GA==",
+      "data" : "/lEeX4nr+fGnF22n1v5Mnn9syxhUfHMKWMXY5I6d9jhxj4+uq8dRX/0CUG7le69hyoH13oWBsjP7vIEYggcBA0+FlrLVxwQyrzr/XYwtJRghqKkFhsLaunRkg3jommqVUpvv+VM0t+nYQf+gjo9/7NLmpidydlcLJsEnXRSfSrUwR/w91ZsZUnHJjncuUoPHjUlUIVO4WUOIzeMuXSTQr32o5G/mjYgvodiZM5RZlzKi//w7Hf/C0ZmKgYvEM2IRaouWVF5LZ5uTAluN5SUXRY1OamtyHxVfgEgX+hvhO/I5J99OSkYYI4K5oOoADoZC"
     },
     "output" : {
-      "signature" : "24125029"
+      "signature" : "83848003"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "H8BjCIdPCy4KGWAO/R0ZZw==",
-      "data" : "HYDvxTd2Cnmd795mj/FAq7SR4TFG6j9h6ZJSOhCzEUhbusSLP1Zx"
+      "counterData" : "dP0A9K7+ycvFXxvqStkEzg==",
+      "data" : "CqivPoLfWKT/+ax7g5B7CnpqEckbfXphY4tULPD5LuTixb6D5pmnPkpPif8oBpJx7OOVAkPOR184aaKEWf+otHluIs3XxM9BAwoc/rJQ93NqiaZ9xra35looa22mEgMST8CfW9a3oFDNkrqgAPbUGIdYHhHmbIksRkiafVRF8xVbORwCb7tPv8uFvnXQaJoilFna8nldwk1jDFuorB/e4GOPLRw="
     },
     "output" : {
-      "signature" : "84183772-66722933"
+      "signature" : "62115690-16183504"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "PDIlQ0vtAWXfMhRLPDiCzQ==",
-      "data" : "K7UPYZ6at1aFc3lFyAc7Uj1i2a9XNBFuOyCDEQOFjXe3hzhI1iXP89hQhtHfjuSeQL+CHGO0fX0luR4Ae7JwFT9L83PNmCT4IlKbyKD/FAuot2svXDA5ZYO3zsGOBo7xD//J7y6UBCfR8CM2MWq4pf3jnX2t0z4wsa/46RNy/4LWZq0SnPAqjNA1TuUmfvMTJ3SaYrdF/aYkXK8G3lc+7jWaY0coFMSv6ENc7Dl/looEzz8JpGWByKAq5fmgBS40mjDOhewYNdNXOYfDxZgfRpTSCB3lh/K6grdf"
+      "counterData" : "7IPdK2nQkzW9bYrs2mnhLw==",
+      "data" : "pe46ndHCW1i8LnGbDLGBXQ=="
     },
     "output" : {
-      "signature" : "46803198-85927455"
+      "signature" : "17334710-52599427"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "8/h8XzVukCr3pgMpVur8+Q==",
-      "data" : "kZD8ThvpXxHAf1lCNiC0ejU6Ezu1yX/CN5poyDOzjewtIbh7fyHTc204BzA++OZjSWdSOUMUZbdC3y3NnE6eo0vV4yvmqZ35PN6e8XJD4pn1yK7ZcmbjzIXIDnYmxBZvRO5dt6M+EWdYPw8q3zkm4EJUCmsxNKk+efrG8lg3QggZwkT0Vx5dX7a9fKcK4UO2zsxUV0oycFR1FNQURy2agFwhCdZyau/hNwx23YYwZUsD49jFlQ=="
+      "counterData" : "SNj3onAGqUO8611TlkpeYQ==",
+      "data" : "hU7a1laSMOi1wA8VLFiCSvc+BojZ8yrTtuE6yxjGqAKLAUM="
     },
     "output" : {
-      "signature" : "46220913-94304266"
+      "signature" : "89629894-76031593"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "Bi/QBjBvbPeyY4wn4t+jgA==",
-      "data" : "Sl4BCpQjgBWvftodnsCYsadNG1hUfNnaGQs06drrO1RBy030zxndeVRdGfYZvgKruoS208UxVWdk8Bfs"
+      "counterData" : "YYjzyFLnEKCkfzSIyu/dQQ==",
+      "data" : "q2av5r3BWwbAdd/JaTCXJd2iBiW5fz1ZXikFKDJUIb0hsGjcLjN6/6pq3IHtKeWbavtN3OoHQ4O9A+rlP90iPviCvMS6A01CTfuf8bAddE4bwOmiNU6ooBfWbcAAFmV+zGx9hWlm9hxuMYH8Vnpjrm0vxA+HByAunzolvo+sh8S6ZRu3dsJkZTxdaKn51xXl1DcdZJZHOJeybkl429elrZNKmwEnmh8D+Hyo/Q=="
     },
     "output" : {
-      "signature" : "11898851-14104446"
+      "signature" : "32407616-53136373"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "8U0VRCoGcs4ahm/1HduihQ==",
-      "data" : "QiXPxdABfeY/V0GjX0XdeBUaxsZyYbBDy6m/m8bQo7sJUo81Zu/q5nqeJ+Nh/Fk05TGPZ4XUPcs+vPFxrBt9XxCAw49BkmjGQtCSqY+uvMRblC8XkeuLty/3A9Y6PrpOx2QBRUPAQe6bdiDNeIrucAxCUFIIqTyPodi7PT/WLexHxIrydDBpZ8aVZ8hBXoRB1qDZ2OzibBSKFwb4dFBA/WLd8o0="
+      "counterData" : "bP4Uz/X4OUEn+S2/7+FnqA==",
+      "data" : "CJswyFLx0MUqETLlzGR+Awy+n+T97tp+wPjtmIeQxEXGpp6dVCOpkWuVmoXA6iT2zL3ZV5nbil4XYJCLhn4zEYL1h1Fm31RR3Xq/8LeWbrDQ/UbYz2Qr"
     },
     "output" : {
-      "signature" : "56550972-95766953"
+      "signature" : "37927626-40439717"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "IlJH5788XB0Mf4xPa+xWIA==",
-      "data" : "Qg5Do6QbhnDWv2xfLijzXniqsBqLAWfMcsCP27SCG+MF95AkUQG97xvyEcRDo7PKCe07wbtRCixXZnQqCO55r+c6zWRSpBJV5TzXohYIoDw3HamHf7F3izT3NG526q3NNBG1zrDJf9Ec4WXFlZduy17bBRBvHhiZMOPv9+mfaotfOWR0KSuCrTR4olCigFbE"
+      "counterData" : "yljf3ZBVI6+g/1gI4P0SVA==",
+      "data" : "2baZbc7BYmZXs6Wq820D8F3CUAPLS0vomT4509fjeQEW0ymBiQhcpXnaJsuPWq9q/YtvI5YymhDU7MZHXILJPi2lbQgl9/UmqLCFeELlAfAm2OAV47FmGRhNf5p6lv0eAIIPwg/3r85U1T+8NWJFmRMTp0tjbz2emuqh/ltolc4yy8bN4Ni2H8DZHmdV2JOWG9Ta/zt3LBZhrz/8eq/nui6+9Wo="
     },
     "output" : {
-      "signature" : "38121650-92280751"
+      "signature" : "63526563-33121830"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "AogoLWAN2cWlFatNPj5+PQ==",
-      "data" : "o+/wWbJ6HcvIMmK4uJxP1E4+Mh8yWVXdz4g63nt7pz7XP2U="
+      "counterData" : "RX3MUgj0DGuj8cssEHuAng==",
+      "data" : "X2crfJOQWE3HL3tLzicziVFfsumMM71LVruyr3AHLY5rJQ=="
     },
     "output" : {
-      "signature" : "44406447-43137648"
+      "signature" : "00259642-46987149"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "63zPQpRGFPtt0KD6to5uFA==",
-      "data" : "wWhQ3+vB5PHqltP74wqVsqthZkQ7lI1tuywsllcKnDWgsJtXlqcctxdQzKkd1ubiWXlqHe1hnQLqC6Ai4/d+02XiZss5K9dV/FTmuHn5K7c2L19zNHBYPm1uToMEayHeNaFGrNmZw6edVNCgP+9AwFfm6AhBxAQTq0wj4G3F1EyWxmU/allMnJjlVA4Whxgq9TKd2xh/gAJKjv6Nzq03BgZvocDa3ciw1YtG4vzcfQXQxBOu"
+      "counterData" : "8zuQ7j6T0BxzyCoxm5BUtA==",
+      "data" : "n3tgL3dwQraYBvgEXsSbpTtcZjKC62/Wl8DHmKNmmv165KPQpF+8u97Cd7MrJTkOs13bkKKG7unDCX+66RFhvcuahqJZugoRX/43hPQ1xaOgHWC2otCNYdMZSWaiK0D6S+OcUXlRLw=="
     },
     "output" : {
-      "signature" : "96839288-55616708"
+      "signature" : "94888417-14645284"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "uTWyI7VF1OPHtu0EfpQJUA==",
-      "data" : "bm/UMFVDU6FftyYTeFiBXfJZ2Ay8FuG8Pqp2jp/4mgcBBk1PBNbeo1fxEog="
+      "counterData" : "L2mDa/Odkgfc+leYVp88ng==",
+      "data" : "cltd4/9wBmGk3N7EQ2UY"
     },
     "output" : {
-      "signature" : "26620943-63742964"
+      "signature" : "08954546-97214504"
     }
   }, {
     "input" : {
-      "signaturePossessionKey" : "wdgjMOGuiEkwEDT6XV8yow==",
-      "signatureKnowledgeKey" : "NS88STZHuirOtISklUpqOA==",
-      "signatureBiometryKey" : "P+iMwXak/W3eBE0i8A2fTg==",
+      "signaturePossessionKey" : "rWSnGv5rNZZ3Eys9kjjomQ==",
+      "signatureKnowledgeKey" : "QXKfIa3j0okOM0qFZVWmSg==",
+      "signatureBiometryKey" : "aLH2+BF074YLfOs16QeoDA==",
       "signatureType" : "possession_knowledge",
       "signatureComponentLength" : "8",
-      "counterData" : "4TsrbWph/aK8jGMyOtJDEA==",
-      "data" : "0uNbbyswbx+oeZTtS49eyhHq7L5MbVsjQz5Rv4OJlESyk51H7P+e44ma3TMiwxxDMrLxfvporkRG43rGBMvsADkT8SaLiov6uniCdQNC3h9THqs67fY+JXYDf4SfuWCze5U7z5DTB/Z938rEy9r9cf8tYyiSIjDh/EXKimI5MZb2ow/D"
+      "counterData" : "aRoGEj+uyOf7OH6IArM1FQ==",
+      "data" : "qhakk/t7TwopHiMzH91HbiGvtbSlOCzDpnnXxDc+QwHlPfiNJikQj+cXTEiree05iO8UTkAJF3FlcbHH48La5rj3Lr96UYoyK1ytQTmHjfWQrDOHbUlysWO5SwH5WrFj+xIpXNIY5YeopyfydUpC3cpLXptPI3XdPRYnP3MNMyv/7KPHEFw6X09VmaKk/iX8QZlBqDMbjbd2RNBrQiHuF6Vd1Zy6pezoK5YftteY"
     },
     "output" : {
-      "signature" : "82257531-87160514"
+      "signature" : "68019997-82425294"
     }
   } ]
 }

--- a/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/lib/util/GenerateVectorDataTest.java
+++ b/powerauth-java-crypto/src/test/java/io/getlime/security/powerauth/crypto/lib/util/GenerateVectorDataTest.java
@@ -799,7 +799,7 @@ public class GenerateVectorDataTest {
             KeyPair deviceKeyPair = keyGenerator.generateKeyPair();
             PrivateKey devicePrivateKey = deviceKeyPair.getPrivate();
 
-            SignatureConfiguration signatureConfiguration = SignatureConfiguration.decimal();
+            SignatureConfiguration signatureConfiguration = SignatureConfiguration.decimal(j);
             PowerAuthClientSignature clientSignature = new PowerAuthClientSignature();
             PowerAuthClientKeyFactory clientKeyFactory = new PowerAuthClientKeyFactory();
 


### PR DESCRIPTION
This PR fixes invalid test vectors in `signatures-offline.json`.